### PR TITLE
Fix i18n bug with toc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 \.gradle
 \build
+.idea
 .project
 .settings/org.eclipse.buildship.core.prefs
 .vscode/settings.json

--- a/docs/config/i18n-definitions.adoc
+++ b/docs/config/i18n-definitions.adoc
@@ -7,7 +7,7 @@
 // end::DE[]
 
 // tag::EN[]
-:toc-title: Inhaltsverzeichnis
+:toc-title: Table of Contents
 :learning_goals: Learning goals
 :chapter-label:
 :introduction: Introduction


### PR DESCRIPTION
The translation for the toc was missing, the definition contained the German text. 🙂 

Closes #83 