### PR TITLE
Add support for external documents

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -53,6 +53,7 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
       run: |
         rm -rf ./build/tmp
+        cp ./docs-ext/curriculum-*.pdf ./build
         zip -r release.zip ./build
     - name: Deploy
       if: startsWith(github.ref, 'refs/tags/')

--- a/README.adoc
+++ b/README.adoc
@@ -124,6 +124,8 @@ In addition, such trainings cover
 * the roles of software architects within development
 * state-of-the-art methods and techniques for developing software architectures
 
+== Additional translations/languages
+include::docs-ext/EXTERNAL_DOCUMENTS_README.adoc[]
 
 == Contributors
 Work on this curriculum started way back in 2007/2008 - and numerous people contributed - either by proposing, crafting and writing content or by commenting, reviewing and otherwise helping to improve.

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
 
   // read document version from file "document.version"
   project.version = project.file("./document.version").text
-  curriculumBaseName = "foundation-curriculum"
+  curriculumBaseName = "curriculum-foundation"
   addSuffixToCurriculum = { suffix ->
     for (extension in ["html", "pdf"]) {
       File source = new File("${buildDir}/${curriculumBaseName}.${extension}")

--- a/docs-ext/EXTERNAL_DOCUMENTS_README.adoc
+++ b/docs-ext/EXTERNAL_DOCUMENTS_README.adoc
@@ -1,0 +1,13 @@
+Copy translated versions (PDF) of the curriculum (other than German or English) to the directory `docs-ext`.
+
+Please make sure, that the file name is well-formed and complies with the following format:
+
+`curriculum-xxxx-lc.pdf`
+
+`xxxx`: insert the name of the curriculum, e.g. `web` or `flex`  +
+`lc`: iso language code of the translation, e.g. `es` (Spanish) or `pt` (Portuguese)
+
+Example: `curriculum-web-es.pdf` <- Spanish version of the WEB curriculum.
+
+**ATTENTION:** For every document that you add to `docs-ext`, you also have to create an entry in `index.adoc`
+so that people can access it from the overview page of this curriculum.

--- a/docs/curriculum-foundation.adoc
+++ b/docs/curriculum-foundation.adoc
@@ -1,8 +1,17 @@
-= CPSA Certified Professional for Software Architecture^(R)^ : - *Foundation Level Curriculum* -
-:toc: left
 // handle numerous attributes. Successful inclusion of this file
 // is ABSOLUTELY NECESSARY!!
 include::config/setup.adoc[]
+
+ifeval::["{language}" == "DE"]
+= Curriculum fürpass:q[<br><br>]Certified Professional forpass:q[<br>]Software Architecture (CPSA)^(R)^pass:q[<br><br>]: *Foundation Level*
+:toc: left
+endif::[]
+
+ifeval::["{language}" == "EN"]
+= Curriculum forpass:q[<br><br>]Certified Professional forpass:q[<br>]Software Architecture (CPSA)^(R)^pass:q[<br><br>]:  *Foundation Level*
+:toc: left
+endif::[]
+
 
 // define terms for toc, learning_goals
 // will have strange results if multiple languages

--- a/docs/curriculum-foundation.adoc
+++ b/docs/curriculum-foundation.adoc
@@ -8,7 +8,7 @@ ifeval::["{language}" == "DE"]
 endif::[]
 
 ifeval::["{language}" == "EN"]
-= Curriculum forpass:q[<br><br>]Certified Professional forpass:q[<br>]Software Architecture (CPSA)^(R)^pass:q[<br><br>]:  *Foundation Level*
+= Curriculum forpass:q[<br><br>]Certified Professional forpass:q[<br>]Software Architecture (CPSA)^(R)^pass:q[<br><br>]: *Foundation Level*
 :toc: left
 endif::[]
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -24,11 +24,11 @@ image:https://img.shields.io/github/issues-closed/isaqb-org/curriculum-foundatio
 
 ==== Recent builds 
 
-- link:foundation-curriculum-de.html[German without Comments (online, html)]
-- link:foundation-curriculum-en.html[English without Comments (online, html)]
-- link:foundation-curriculum-remarks-de-en.html[German/English with Comments (online, html)]
-- link:foundation-curriculum-de.pdf[German without Comments (PDF)]
-- link:foundation-curriculum-en.pdf[English without Comments (PDF)]
+- link:curriculum-foundation-de.html[German without Comments (online, html)]
+- link:curriculum-foundation-en.html[English without Comments (online, html)]
+- link:curriculum-foundation-remarks-de-en.html[German/English with Comments (online, html)]
+- link:curriculum-foundation-de.pdf[German without Comments (PDF)]
+- link:curriculum-foundation-en.pdf[English without Comments (PDF)]
 
 More versions https://github.com/isaqb-org/curriculum-foundation/tags[(tagged) on the Github Releases page.]
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
With the changes of this branch, we can support the simple upload of translated curricula. They only have to be uploaded to the folder `docs-ext` and will automatically be added to the next release. 

**ATTENTION**:  
The name of the resulting file has been changed from `foundation-curriculum` to `curriculum-foundation` for three reasons:
1. It is now the same format that all advanced modules have as file name (e.g. `curriculum-web`)
2. It allows us to use the same script for advanced modules as well as foundation modules without having to change anything
3. It is now the same name as the repository.

Drawback: with the next release (2021.1), we have to adjust the URL of the Website pointing to this release one more time. 