### PR TITLE
Add PDF Files to Release

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -24,10 +24,12 @@ jobs:
       uses: actions/checkout@v2
     - name: Checkout Submodules
       uses: textbook/git-checkout-submodule-action@master
-    - name: Set up JDK 11
+    - name: Verify Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
+    - name: Set up JDK 14
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 14
     - name: Execute Gradle Build
       uses: eskatos/gradle-command-action@v1
       with:

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -42,7 +42,7 @@ jobs:
       run: echo "RELEASE_VERSION=${GITHUB_REF:10}" >> $GITHUB_ENV
     - name: Create New Release
       if: startsWith(github.ref, 'refs/tags/')
-      id: create_release
+      id: create-release
       uses: actions/create-release@latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
@@ -57,21 +57,34 @@ jobs:
         rm -rf ./build/tmp
         cp ./docs-ext/curriculum-*.pdf ./build 2>/dev/null || :
         zip -r release.zip ./build
+        mkdir release_dir
+        cp ./build/curriculum-*.pdf ./release_dir 2>/dev/null || :
+        mv release.zip ./release_dir/release-${{ env.RELEASE_VERSION }}.zip
     - name: Deploy
       if: startsWith(github.ref, 'refs/tags/')
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build
+        user_name: 'github-actions[bot]'
+        user_email: 'github-actions[bot]@users.noreply.github.com'
         commit_message: Publish Release ${{ env.RELEASE_VERSION }}
     - name: Upload Release Files
       if: startsWith(github.ref, 'refs/tags/')
-      id: upload-release-asset
-      uses: actions/upload-release-asset@v1
+      id: upload-release-assets
+      uses: actions/github-script@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: ./release.zip
-        asset_name: release-${{ env.RELEASE_VERSION }}.zip
-        asset_content_type: application/zip
+        script: |
+          const fs = require('fs').promises;
+          const { repo: { owner, repo }, sha } = context;
+
+          for (let file of await fs.readdir('./release_dir')) {
+            await github.repos.uploadReleaseAsset({
+              owner, repo,
+              release_id: ${{ steps.create-release.outputs.id }},
+              name: file,
+              data: await fs.readFile(`./release_dir/${file}`)
+            });
+          }

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -22,6 +22,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Checkout submodules
       uses: textbook/git-checkout-submodule-action@master
+    - name: Verify Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
     - name: Set up JDK 14
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/build_releasecandidate.yml
+++ b/.github/workflows/build_releasecandidate.yml
@@ -23,6 +23,8 @@ jobs:
       uses: actions/checkout@v2
     - name: Checkout Submodules
       uses: textbook/git-checkout-submodule-action@master
+    - name: Verify Gradle Wrapper
+      uses: gradle/wrapper-validation-action@v1
     - name: Set up JDK 14
       uses: actions/setup-java@v1
       with:

--- a/.github/workflows/build_releasecandidate.yml
+++ b/.github/workflows/build_releasecandidate.yml
@@ -56,7 +56,10 @@ jobs:
         rm -rf ./build/tmp
         cp ./docs-ext/curriculum-*.pdf ./build 2>/dev/null || :
         zip -r release.zip ./build
-    - name: Deploy Release Candidate
+        mkdir release_dir
+        cp ./build/curriculum-*.pdf ./release_dir 2>/dev/null || :
+        mv release.zip ./release_dir/release-${{ env.RELEASE_VERSION }}.zip
+    - name: Deploy Release Candidate to GitHub Pages
       if: startsWith(github.ref, 'refs/tags/')
       uses: peaceiris/actions-gh-pages@v3
       with:
@@ -67,14 +70,22 @@ jobs:
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
         commit_message: Publish Release Candidate ${{ env.RELEASE_VERSION }}
-    - name: Upload Release Files
+    - name: Upload Release Candidate Files
       if: startsWith(github.ref, 'refs/tags/')
-      id: upload-release-candidate-asset
-      uses: actions/upload-release-asset@v1
+      id: upload-release-candidate-assets
+      uses: actions/github-script@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        upload_url: ${{ steps.create-release-candidate.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: ./release.zip
-        asset_name: release-${{ env.RELEASE_VERSION }}.zip
-        asset_content_type: application/zip
+        script: |
+          const fs = require('fs').promises;
+          const { repo: { owner, repo }, sha } = context;
+
+          for (let file of await fs.readdir('./release_dir')) {
+            await github.repos.uploadReleaseAsset({
+              owner, repo,
+              release_id: ${{ steps.create-release-candidate.outputs.id }},
+              name: file,
+              data: await fs.readFile(`./release_dir/${file}`)
+            });
+          }


### PR DESCRIPTION
PDF files of the curriculum are now added to each release and release candidate on github as direct download. Release Candidates are also already published to GitHub Pages.

Sorry for the delay, I thought I had already added that feature.

close #216 