### PR TITLE
Fix translation of TOC

### DIFF
--- a/docs/config/i18n-definitions.adoc
+++ b/docs/config/i18n-definitions.adoc
@@ -1,5 +1,4 @@
 // tag::DE[]
-:toc-title: Inhaltsverzeichnis
 :learning_goals: Lernziele
 :chapter-label:
 :introduction: Einleitung
@@ -7,7 +6,6 @@
 // end::DE[]
 
 // tag::EN[]
-:toc-title: Table of Contents
 :learning_goals: Learning goals
 :chapter-label:
 :introduction: Introduction

--- a/docs/curriculum-foundation.adoc
+++ b/docs/curriculum-foundation.adoc
@@ -4,6 +4,7 @@ include::config/setup.adoc[]
 
 ifeval::["{language}" == "DE"]
 = Curriculum fürpass:q[<br><br>]Certified Professional forpass:q[<br>]Software Architecture (CPSA)^(R)^pass:q[<br><br>]: *Foundation Level*
+:toc-title: Inhaltsverzeichnis
 :toc: left
 endif::[]
 


### PR DESCRIPTION
toc-title has to be set directly beneath the very first heading.
Otherwise, it is ignored.
We can remove it from i18n-definitions.adoc

close #236 