### PR TITLE
Delete most occurrences of the term "quality"

### DIFF
--- a/docs/01-basics/01-basics-duration-terms.adoc
+++ b/docs/01-basics/01-basics-duration-terms.adoc
@@ -21,8 +21,7 @@ Softwarearchitekt:innen und deren Verantwortlichkeiten;
 Rolle; 
 Aufgaben und benötigte Fähigkeiten; 
 Stakeholder und deren Anliegen; 
-funktionale Anforderungen; 
-{glossary_url}quality-requirement[Qualitätsanforderungen]; 
+Anforderungen; 
 {glossary_url}constraints[Randbedingungen]; 
 Einflussfaktoren; 
 Typen von IT-Systemen (eingebettete Systeme; Echtzeitsysteme; Informationssysteme etc.)
@@ -47,8 +46,7 @@ architecture domains; {glossary_url}structure[structure];
 software architects and their responsibilities; 
 tasks and required skills; 
 stakeholders and their concerns; 
-functional and {glossary_url}quality-requirement[quality] 
-requirements of systems; 
+requirements;
 {glossary_url}constraints[constraints]; 
 influencing factors; 
 types of IT systems (embedded systems; real-time systems; information systems etc.)

--- a/docs/01-basics/LZ-1-02.adoc
+++ b/docs/01-basics/LZ-1-02.adoc
@@ -6,8 +6,8 @@
 Softwarearchitekt:innen können folgenden Nutzen und wesentlichen Ziele von Softwarearchitektur begründen:
 
 * Entwurf, Implementierung, Pflege und Betrieb von Systemen zu unterstützen
-* Qualitätsanforderungen wie Zuverlässigkeit, Wartbarkeit, Änderbarkeit, Sicherheit zu erreichen
 * funktionale Anforderungen zu erreichen bzw. deren Erfüllbarkeit sicherzustellen
+* Anforderungen wie Zuverlässigkeit, Wartbarkeit, Änderbarkeit, Sicherheit zu erreichen
 * Verständnis für Strukturen und Konzepte des Systems zu vermitteln, bezogen auf sämtliche relevanten Stakeholder
 * systematisch Komplexität zu reduzieren 
 * architekturrelevante Richtlinien für Implementierung und Betrieb zu spezifizieren
@@ -22,8 +22,8 @@ Softwarearchitekt:innen können folgenden Nutzen und wesentlichen Ziele von Soft
 Software architects can justify the following essential goals and benefits of software architecture:
 
 * support the design, implementation, maintenance, and operation of systems
-* achieve quality requirements such as reliability, maintainability, changeability, security, etc.
 * achieve functional requirements or ensure that they can be met
+* achieve requirements such as reliability, maintainability, changeability, security, etc.
 * ensure that the the system's structures and concepts are understood by all relevant stakeholders
 * systematically reduce complexity
 * specify architecturally relevant guidelines for implementation and operation

--- a/docs/01-basics/LZ-1-03.adoc
+++ b/docs/01-basics/LZ-1-03.adoc
@@ -6,7 +6,7 @@
 Softwarearchitekt:innen können Ihre Aufgaben und Ergebnisse in den gesamten Lebenszyklus von IT-Systemen einordnen.
 Sie können:
 
-* Konsequenzen von Änderungen bei funktionalen Anforderungen, Qualitätsanforderungen, Technologien oder der Systemumgebung im Bezug auf die Softwarearchitektur erkennen
+* Konsequenzen von Änderungen bei Anforderungen, Technologien oder der Systemumgebung im Bezug auf die Softwarearchitektur erkennen
 * inhaltliche Zusammenhänge zwischen IT-Systemen und den unterstützten Geschäfts- und Betriebsprozessen aufzeigen
 
 // end::DE[]
@@ -18,7 +18,7 @@ Sie können:
 Software architects understand their tasks and can integrate their results into the overall lifecycle of IT systems.
 They can:
 
-* identify the consequences of changes in functional requirements, quality requirements, technologies, or the system environment in relation to software architecture
+* identify the consequences of changes in requirements, technologies, or the system environment in relation to software architecture
 * elaborate on relationships between IT-systems and the supported business and operational processes
 
 // end::EN[]

--- a/docs/01-basics/LZ-1-04.adoc
+++ b/docs/01-basics/LZ-1-04.adoc
@@ -2,18 +2,17 @@
 // tag::DE[]
 [[LZ-1-4]]
 ==== LZ 1-4: Aufgaben und Verantwortung von Softwarearchitekt:innen verstehen (R1)
-Softwarearchitekt:innen tragen die Verantwortung für die Erreichung der geforderten oder notwendigen Qualität und die Erstellung des Architekturentwurfs der Lösung.
+Softwarearchitekt:innen tragen die Verantwortung für die Erreichung der Anforderungen und die Erstellung des Architekturentwurfs der Lösung.
 Sie müssen diese Verantwortung, abhängig vom jeweiligen Prozess- oder Vorgehensmodell, mit der Gesamtverantwortung der Projektleitung oder anderen Rollen koordinieren.
 
 Aufgaben und Verantwortung von Softwarearchitekt:innen:
 
-* Anforderungen und Randbedingungen klären, hinterfragen und bei Bedarf verfeinern
-Hierzu zählen neben den funktionalen Anforderungen (Required Features) insbesondere die geforderten Qualitätsmerkmale (_Required Constraints_)
+* Anforderungen und Randbedingungen klären, hinterfragen und bei Bedarf verfeinern, inbseondere _Required Features und__Required Constraints_
 * Strukturentscheidungen hinsichtlich Systemzerlegung und Bausteinstruktur treffen, dabei Abhängigkeiten und Schnittstellen zwischen den Bausteinen festlegen
 * Querschnittskonzepte entscheiden (beispielsweise Persistenz, Kommunikation, GUI) und bei Bedarf umsetzen
 * Softwarearchitektur auf Basis von Sichten, Architekturmustern sowie technischen und Querschnittskonzepten kommunizieren und dokumentieren
 * Umsetzung und Implementierung der Architektur begleiten, Rückmeldungen der beteiligten Stakeholder bei Bedarf in die Architektur einarbeiten, Konsistenz von Quellcode und Softwarearchitektur prüfen und sicherstellen
-* Softwarearchitektur analysieren und bewerten, insbesondere hinsichtlich Risiken bezüglich der geforderten Qualitätsmerkmale
+* Softwarearchitektur analysieren und bewerten, insbesondere hinsichtlich Risiken bezüglich der Erreichung von Anforderungen
 * Die Konsequenzen von Architekturentscheidungen erkennen, aufzeigen und gegenüber anderen Stakeholdern argumentieren
 
 Sie sollen selbständig die Notwendigkeit von Iterationen bei allen Aufgaben erkennen und Möglichkeiten für entsprechende Rückmeldung aufzeigen.
@@ -23,18 +22,18 @@ Sie sollen selbständig die Notwendigkeit von Iterationen bei allen Aufgaben erk
 // tag::EN[]
 [[LG-1-4]]
 ==== LG 1-4: Understand software architects' tasks and responsibilities (R1)
-Software architects are responsible for achieving the required or necessary quality and creating the architecture design of a solution.
+Software architects are responsible for meeting requirements and and creating the architecture design of a solution.
 Depending on the actual approach or process model used, they must align this responsibility with the overall responsibilities of project management and/or other roles.
 
 Tasks and responsibilities of software architects:
 
-* clarify and scrutinize requirements and constraints, and refine them if necessary
-Together with functional requirements (required features), this includes the required quality characteristics (_required constraints_)
+* clarify and scrutinize requirements and constraints, and refine them if necessary,
+  including _required features_ and _required constraints_
 * decide how to decompose the system into building blocks, while determining dependencies and interfaces between the building blocks
 * determine and decide on cross-cutting concepts (for instance persistence, communication, GUI etc.)
 * communicate and document software architecture based on views, architectural patterns, cross-cutting and technical concepts
 * accompany the realization and implementation of the architecture; integrate feedback from relevant stakeholders into the architecture if necessary; review and ensure the consistency of source code and software architecture
-* analyze and evaluate software architecture, especially with respect to risks involving the quality requirements
+* analyze and evaluate software architecture, especially with respect to risks that involve meeting the requirements
 * identify, highlight, and justify the consequences of architectural decisions to other stakeholders
 
 They should independently recognize the necessity of iterations in all tasks and point out possibilities for appropriate and relevant feedback.

--- a/docs/01-basics/LZ-1-07.adoc
+++ b/docs/01-basics/LZ-1-07.adoc
@@ -5,9 +5,9 @@
 
 Softwarearchitekt:innen können:
 
-* langfristige Qualitätsanforderungen sowie deren Abgrenzung gegen (kurzfristige) Projektziele erklären
+* langfristige Anforderungen sowie deren Abgrenzung gegen (kurzfristige) Projektziele erklären
 * Potentielle Zielkonflikte zwischen kurz- und langfristigen Zielen erklären, um eine für alle Beteiligten tragfähige Lösung zu erarbeiten
-* Qualitätsanforderungen identifizieren und präzisieren
+* Anforderungen identifizieren und präzisieren
 
 // end::DE[]
 
@@ -17,8 +17,8 @@ Softwarearchitekt:innen können:
 
 Software architects can:
 
-* explain long-term quality requirements and their differentiation from (short-term) project goals
+* explain long-term requirements and their differentiation from (short-term) project goals
 * explain potential conflicts between short-term and long-term goals, in order to find a suitable solution for all stakeholders
-* identify and specify quality requirements
+* identify and specify requirements
 
 // end::EN[]

--- a/docs/02-design/LZ-2-02.adoc
+++ b/docs/02-design/LZ-2-02.adoc
@@ -5,7 +5,7 @@
 
 Softwarearchitekt:innen können:
 
-* Softwarearchitekturen auf Basis bekannter funktionaler und Qualitätsanforderungen für nicht sicherheits- oder unternehmenskritische Softwaresysteme entwerfen und angemessen kommunizieren und dokumentieren
+* Softwarearchitekturen auf Basis bekannter Anforderungen für nicht sicherheits- oder unternehmenskritische Softwaresysteme entwerfen und angemessen kommunizieren und dokumentieren
 * Strukturentscheidungen hinsichtlich Systemzerlegung und Bausteinstruktur treffen, dabei Abhängigkeiten zwischen Bausteinen festlegen
 * gegenseitige Abhängigkeiten und Abwägungen bezüglich Entwurfsentscheidungen erkennen und begründen
 * Begriffe _Blackbox_ und _Whitebox_ erklären und zielgerichtet anwenden
@@ -23,7 +23,7 @@ Softwarearchitekt:innen können:
 
 Software architects are able to:
 
-* design and appropriately communicate and document software architectures based upon known functional and quality requirements for software systems that are neither safety- nor business-critical
+* design and appropriately communicate and document software architectures based upon known requirements for software systems that are neither safety- nor business-critical
 * make structure-relevant decisions regarding system decomposition and building-block structure and deliberately design dependencies between building blocks
 * recognize and justify interdependencies and trade-offs of design decisions
 * explain the terms _black box_ and _white box_ and apply them purposefully

--- a/docs/02-design/LZ-2-03.adoc
+++ b/docs/02-design/LZ-2-03.adoc
@@ -9,8 +9,7 @@ Sie verstehen, dass ihre Entscheidungen weitere Anforderungen und Einschränkung
 Sie erkennen und berücksichtigen den Einfluss von:
 
 * produktbezogenen Faktoren wie (R1)
-** funktionale Anforderungen 
-** Qualitätsanforderungen und Qualitätsziele
+** Anforderungen und Ziele
 ** zusätzliche Faktoren wie Produktkosten, beabsichtigtes Lizenzmodell oder Geschäftsmodell des Systems
 
 * technischen Faktoren wie (R1-R3)
@@ -51,8 +50,8 @@ They understand that their decisions may imply further requirements and constrai
 They should recognize and account for the impact of:
 
 * product-related factors such as (R1)
-** functional requirements 
-** quality requirements and quality goals
+** functional requirements
+** requirements and goals
 ** additional factors such as product cost, intended licensing model, or business model of the system
 
 * technological factors such as (R1-R3)

--- a/docs/02-design/LZ-2-06.adoc
+++ b/docs/02-design/LZ-2-06.adoc
@@ -10,7 +10,7 @@ Mit einer Prüfungsrelevanz, die jeweils von dem unten aufgeführten konkreten P
 
 * die unten aufgeführten Gestaltungsprinzipien zu erläutern und mit Beispielen zu illustrieren
 * zu erklären, wie diese Prinzipien angewendet werden sollen
-* darzulegen, wie Qualitätsanforderungen die Anwendung dieser Prinzipien beeinflussen
+* darzulegen, wie Anforderungen die Anwendung dieser Prinzipien beeinflussen
 * die Auswirkungen der Entwurfsprinzipien auf die Implementierung zu erläutern
 * Quellcode- und Architekturentwürfe zu analysieren, um zu beurteilen, ob diese Entwurfsprinzipien angewendet wurden oder angewendet werden sollten
 
@@ -65,7 +65,7 @@ With relevance for the examination depending on the specific principle listed be
 
 * explain the design principles listed below and can illustrate them with examples
 * explain how those principles are to be applied
-* explain how the quality requirements determine which principles should be applied
+* explain how the requirements determine which principles should be applied
 * explain the impact of design principles on the implementation
 * analyze source code and architecture designs to evaluate whether these design principles have been applied or should be applied
 

--- a/docs/03-documentation/LZ-3-01.adoc
+++ b/docs/03-documentation/LZ-3-01.adoc
@@ -1,8 +1,8 @@
 // tag::DE[]
 [[LZ-3-1]]
-==== LZ 3-1: Qualitätsmerkmale technischer Dokumentation erläutern und berücksichtigen (R1)
+==== LZ 3-1: Anforderungen an technische Dokumentation erläutern und berücksichtigen (R1)
 
-Softwarearchitekt:innen kennen die wesentlichen Qualitätsmerkmale technischer Dokumentation und können diese bei der Dokumentation von Systemen berücksichtigen bzw. erfüllen:
+Softwarearchitekt:innen kennen die wesentlichen Anforderungen an technische Dokumentation und können diese bei der Dokumentation von Systemen berücksichtigen bzw. erfüllen:
 
 * Verständlichkeit, Korrektheit, Effizienz, Angemessenheit, Wartbarkeit
 * Orientierung von Form, Inhalt und Detailgrad an Zielgruppe der Dokumentation
@@ -13,8 +13,8 @@ Sie wissen, dass Verständlichkeit technischer Dokumentation nur von deren Zielg
 
 // tag::EN[]
 [[LG-3-1]]
-==== LG 3-1: Explain and consider the quality of technical documentation (R1)
-Software architects know the quality requirements of technical documentation and can consider and fulfil those when documenting systems:
+==== LG 3-1: Explain and consider the requirements of technical documentation (R1)
+Software architects know the requirements of technical documentation and can consider and fulfil them when documenting systems:
 
 * understandability, correctness, efficiency, appropriateness, maintainability
 * form, content, and level of detail tailored to the stakeholders


### PR DESCRIPTION
... except those in LG 2-8 and Section 4, which are explicitly devoted
to the subject.

This is to help avoid confusion between the use of the term in common
language, and ISO 25010, with the goal of firmly placing the remaining
these uses in the context of ISO 25010.