### PR TITLE
Fix typo in LG-1-10

### DIFF
--- a/docs/01-basics/LZ-1-10.adoc
+++ b/docs/01-basics/LZ-1-10.adoc
@@ -25,7 +25,7 @@ Software architects know different types of IT systems, for example:
 * information systems
 * decision support, data warehouse or business intelligence systems
 * mobile systems
-* _Cloud-native_ Systeme (refer to <<cncf>>)
+* _Cloud-native_ systems (refer to <<cncf>>)
 * batch processes or systems
 * systems based upon machine learning or artificial intelligence
 * hardware-related systems; here they understand the necessity of hardware/software co-design (temporal and content-related dependencies of hardware and software design)


### PR DESCRIPTION
While reviewing the learning goals for changes in the RC, found a typo in the English description of LG-1-10:
_Cloud-native_ Systeme -> _Cloud-native_ systems
This PR fixes the typo.
