### PR TITLE
moves functional/quality requirements in LG 2-3 up one level

### DIFF
--- a/docs/02-design/LZ-2-03.adoc
+++ b/docs/02-design/LZ-2-03.adoc
@@ -8,10 +8,9 @@ Sie verstehen, dass ihre Entscheidungen zu weiteren Anforderungen (inklusive Ran
 
 Sie erkennen und berücksichtigen den Einfluss von:
 
-* produktbezogenen Anforderungen und Trends wie (R1)
-** funktionale Anforderungen
-** Qualitätsanforderungen
-** technologische, organisatorische und regulatorische Randbedingungen.
+* funktionale Anforderungen (R1)
+
+* Qualitätsanforderungen (R1)
 
 * Technologische Randbedingungen wie 
 ** bestehende oder geplante Hardware- und Software-Infrastruktur (R1)
@@ -27,17 +26,17 @@ Sie erkennen und berücksichtigen den Einfluss von:
 ** Verfügbarkeit von Ressourcen wie Budget, Zeit und Personal (R1)
 ** Verfügbarkeit, Qualifikation und Engagement von Mitarbeitenden (R1)
 
-* Regulatorischen Randbedingungen wie (R2)
-** lokale und internationale rechtliche Einschränkungen
-** Vertrags- und Haftungsfragen
-** Datenschutzgesetze und Gesetze zum Schutz der Privatsphäre
-** Fragen der Einhaltung oder Verpflichtungen zur Beweislast
+* Regulatorischen Randbedingungen wie
+** lokale und internationale rechtliche Einschränkungen (R2)
+** Vertrags- und Haftungsfragen (R2)
+** Datenschutzgesetze und Gesetze zum Schutz der Privatsphäre (R2)
+** Fragen der Einhaltung oder Verpflichtungen zur Beweislast (R2)
 
-* Trends wie (R3)
-** Markttrends
-** Technologietrends (z.B. Blockchain, Microservices)
-** Methodik-Trends (z.B. agil)
-** (potenzielle) Auswirkungen weiterer Stakeholderinteressen und vorgegebener oder extern festgelegter Designentscheidungen 
+* Trends wie
+** Markttrends (R3)
+** Technologietrends (z.B. Blockchain, Microservices) (R3)
+** Methodik-Trends (z.B. agil) (R3)
+** (potenzielle) Auswirkungen weiterer Stakeholderinteressen und vorgegebener oder extern festgelegter Designentscheidungen (R3) 
 // end::DE[]
 
 // tag::EN[]
@@ -51,11 +50,9 @@ They understand that their decisions can lead to additional requirements (includ
 
 They should recognize and account for the impact of:
 
-* product-related factors and trends such as (R1)
-** functional requirements
-** quality requirements
-** technological, organizational and regulatory constraints.
+* functional requirements (R1)
 
+* quality requirements (R1)
 
 * Technological constraints such as 
 ** existing or planned hardware and software infrastructure (R1)
@@ -71,17 +68,17 @@ They should recognize and account for the impact of:
 ** available resources like budget, time, and staff (R1)
 ** availability, skill set, and commitment of staff (R1)
 
-* Regulatory constraints such as (R2)
-** local and international legal constraints
-** contract and liability issues
-** data protection​ and privacy laws
-** compliance issues or obligations to provide burden of proof​
+* Regulatory constraints such as
+** local and international legal constraints (R2)
+** contract and liability issues (R2)
+** data protection​ and privacy laws (R2)
+** compliance issues or obligations to provide burden of proof (R2)​
 
-* Trends such as (R3)
-** market trends
-** technology trends (e.g. blockchain, microservices)
-** methodology trends (e.g. agile)
-** (potential) impact of further stakeholder concerns and mandated design decisions
+* Trends such as
+** market trends (R3)
+** technology trends (e.g. blockchain, microservices) (R3)
+** methodology trends (e.g. agile) (R3)
+** (potential) impact of further stakeholder concerns and mandated design decisions (R3)
 
 Software architects are able to describe how those factors can influence design decisions and can elaborate on the consequences of changing influencing factors by providing examples for some of them (R2).
 


### PR DESCRIPTION
suggests to move functional/quality requirements in LG 2-3 on the same level like constraints

- right now technological, organization and regulatory constraints are listed as third sub-bullet below the first bullet redundantly to other major bullets.
- functional/quality requirements should be on the same logical level like constraints which is right now not the case

I am aware that this a change regarding the learning objectives that might be declined, as you may only accept syntax changes here. However, I suggest this pull request to bring this issue to your attention. Feel free, to close this pull request if you cannot accept this suggestion.