### PR TITLE
adapts the learn goal category notation to use commas only

### DIFF
--- a/docs/02-design/LZ-2-03.adoc
+++ b/docs/02-design/LZ-2-03.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LZ-2-3]]
-==== LZ 2-3: Anforderungen klären und berücksichtigen können (R1-R3)
+==== LZ 2-3: Anforderungen klären und berücksichtigen können (R1,R2,R3)
 
 Softwarearchitekt:innen können Anforderungen (inklusive Randbedingungen als Einschränkungen der Entwurfsfreiheit) klären und berücksichtigen.
 Sie verstehen, dass ihre Entscheidungen zu weiteren Anforderungen (inklusive Randbedingungen) an das zu entwerfende System, seine Architektur oder den Entwicklungsprozess führen können. 
@@ -42,7 +42,7 @@ Sie erkennen und berücksichtigen den Einfluss von:
 
 // tag::EN[]
 [[LG-2-3]]
-==== LG 2-3: Identify and Consider Factors Influencing Software Architecture (R1-R3)
+==== LG 2-3: Identify and Consider Factors Influencing Software Architecture (R1,R2,R3)
 
 
 Software architects are able to clarify and consider requirements (including constraints that restrict their decisions).

--- a/docs/02-design/LZ-2-05.adoc
+++ b/docs/02-design/LZ-2-05.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LZ-2-5]]
-==== LZ 2-5: Wichtige Lösungsmuster beschreiben, erklären und angemessen anwenden (R1, R3)
+==== LZ 2-5: Wichtige Lösungsmuster beschreiben, erklären und angemessen anwenden (R1,R3)
 
 
 Softwarearchitekt:innen kennen verschiedene Architekturmuster (siehe unten) und können sie gegebenenfalls anwenden.
@@ -54,7 +54,7 @@ Softwarearchitekt:innen kennen wesentliche Quellen für Architekturmuster, beisp
 
 // tag::EN[]
 [[LG-2-5]]
-==== LG 2-5: Describe, Explain and Appropriately Apply Important Solution Patterns (R1, R3)
+==== LG 2-5: Describe, Explain and Appropriately Apply Important Solution Patterns (R1,R3)
 
 
 Software architects know:

--- a/docs/02-design/LZ-2-06.adoc
+++ b/docs/02-design/LZ-2-06.adoc
@@ -1,7 +1,7 @@
 // tag::DE[]
 
 [[LZ-2-6]]
-==== LZ 2-6: Entwurfsprinzipien erläutern und anwenden (R1-R3)
+==== LZ 2-6: Entwurfsprinzipien erläutern und anwenden (R1,R2,R3)
 
 Softwarearchitekt:innen sind in der Lage zu erklären, was Entwurfsprinzipien sind.
 Sie können deren grundlegende Ziele und deren Anwendung im Hinblick auf Softwarearchitektur skizzieren. (R2)
@@ -28,7 +28,7 @@ Softwarearchitekt:innen sind in der Lage:
 * Trennung von Verantwortlichkeiten (Separation of Concerns - SoC) (R1)
 * Lose, aber funktionell ausreichende Kopplung (R1) von Bausteinen, siehe <<LZ-2-7, Lernziel 2-7>>
 * Hohe Kohäsion (R1)
-* SOLID-Prinzipien (R1-R3), soweit sie auf architektonischer Ebene von Relevanz sind:
+* SOLID-Prinzipien (R1,R2,R3), soweit sie auf architektonischer Ebene von Relevanz sind:
 ** S: Single-Responsibility-Prinzip (R1) und seine Beziehung zu SoC
 ** O: Offen/geschlossen-Prinzip (R1)
 ** L: Liskov'sches Substitutionsprinzip (R3) als eine Möglichkeit, Konsistenz und konzeptionelle Integrität beim objektorientierten Design zu erreichen
@@ -47,7 +47,7 @@ Softwarearchitekt:innen sind in der Lage:
 * als Motiv der Prinzipien KISS (R1) und YAGNI (R2)
 
 
-**Erwarte Fehler** (R1-R2)
+**Erwarte Fehler** (R1,R2)
 
 * als Mittel für den Entwurf robuster und widerstandsfähiger Systeme (R1)
 * als eine Verallgemeinerung des Robustheitsgrundsatzes (_Postel's law_) (R2)
@@ -60,7 +60,7 @@ Softwarearchitekt:innen kennen weitere Prinzipien (etwa CUPID, siehe <<nygard-cu
 // tag::EN[]
 
 [[LG-2-6]]
-==== LG 2-6: Explain and Use Design Principles (R1-R3)
+==== LG 2-6: Explain and Use Design Principles (R1,R2,R3)
 Software architects are able to explain what design principles are.
 They can outline their general objectives and applications with regard to software architecture. (R2)
 
@@ -78,13 +78,13 @@ Software architects are able to:
 * as a design technique, where building blocks are dependent on the abstractions rather than depending on implementations
 * interfaces as abstractions
 
-**Modularization** (R1-R3)
+**Modularization** (R1,R2,R3)
 
 * information hiding and encapsulation (R1)
 * separation of concerns - SoC (R1)
 * loose, but functionally sufficient, coupling (R1) of building blocks, see <<LG-2-7, LG 2-7>>
 * high cohesion (R1)
-* SOLID principles (R1-R3), which have, to a certain extent, relevance at the architectural level
+* SOLID principles (R1,R2,R3), which have, to a certain extent, relevance at the architectural level
 ** S: Single responsibility principle (R1) and its relation to SoC
 ** O: Open/closed principle (R1)
 ** L: Liskov substitution principle (R3) as a way to achieve consistency and conceptual integrity in OO design
@@ -96,12 +96,12 @@ Software architects are able to:
 * meaning uniformity (homogeneity, consistency) of solutions for similar problems (R2)
 * as a means to achieve the principle of least surprise (R3)
 
-**Simplicity** (R1-R2)
+**Simplicity** (R1,R3)
 
 * as a means to reduce complexity (R1)
 * as the driving factor behind KISS (R3) and YAGNI (R3)
 
-**Expect Errors** (R1-R2)
+**Expect Errors** (R1,R2)
 
 * as a means to design for robust and resilient systems (R1)
 * as a generalization of the robustness principle (_Postel's law_) (R2)

--- a/docs/02-design/LZ-2-09.adoc
+++ b/docs/02-design/LZ-2-09.adoc
@@ -2,7 +2,7 @@
 // tag::DE[]
 
 [[LZ-2-9]]
-==== LZ 2-9: Schnittstellen entwerfen und festlegen (R1-R3)
+==== LZ 2-9: Schnittstellen entwerfen und festlegen (R1,R2,R3)
 
 Softwarearchitekt:innen kennen die hohe Bedeutung von Schnittstellen. Sie können Schnittstellen zwischen Architekturbausteinen sowie externe Schnittstellen zwischen dem System und Elementen außerhalb des Systems entwerfen bzw. festlegen.
 
@@ -22,7 +22,7 @@ Sie kennen:
 
 // tag::EN[]
 [[LG-2-9]]
-==== LG 2-9: Design and Define Interfaces (R1-R3)
+==== LG 2-9: Design and Define Interfaces (R1,R2,R3)
 
 Software architects know about the importance of interfaces. They are able to design or specify interfaces between architectural building blocks as well as external interfaces between the system and elements outside of the system.
 

--- a/docs/03-documentation/LZ-3-02.adoc
+++ b/docs/03-documentation/LZ-3-02.adoc
@@ -1,6 +1,6 @@
 // tag::DE[]
 [[LZ-3-2]]
-==== LZ 3-2: Softwarearchitekturen beschreiben und kommunizieren (R1, R3)
+==== LZ 3-2: Softwarearchitekturen beschreiben und kommunizieren (R1,R2,R3)
 
 Softwarearchitekt:innen nutzen Dokumentation zur Unterstützung bei Entwurf, Implementierung und Weiterentwicklung (auch genannt _Wartung_ oder _Evolution_) von Systemen. (R2)
 
@@ -25,7 +25,7 @@ Sie können beispielsweise die folgenden Merkmale von Dokumentation je nach Situ
 
 // tag::EN[]
 [[LG-3-2]]
-==== LG 3-2: Describe and Communicate Software Architectures (R1, R3)
+==== LG 3-2: Describe and Communicate Software Architectures (R1,R2,R3)
 
 Software architects use documentation to support the design, implementation and further development (also called _maintenance_ or _evolution_) of systems (R2)
 

--- a/docs/03-documentation/LZ-3-03.adoc
+++ b/docs/03-documentation/LZ-3-03.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LZ-3-3]]
-==== LZ 3-3: Notations-/Modellierungsmittel für Beschreibung von Softwarearchitektur erläutern und anwenden (R2-R3)
+==== LZ 3-3: Notations-/Modellierungsmittel für Beschreibung von Softwarearchitektur erläutern und anwenden (R2,R3)
 
 Softwarearchitekt:innen kennen mindestens folgende UML-Diagramme (siehe <<uml>>) zur Notation von Architektursichten:
 
@@ -19,7 +19,7 @@ Softwarearchitekt:innen kennen Alternativen zu UML, beispielsweise (R3)
 
 // tag::EN[]
 [[LG-3-3]]
-==== LG 3-3: Explain and Apply Notations/Models to Describe Software Architecture (R2-R3)
+==== LG 3-3: Explain and Apply Notations/Models to Describe Software Architecture (R2,R3)
 
 Software architects know at least the following UML (see <<uml>>) diagrams to describe architectural views:
 

--- a/docs/03-documentation/LZ-3-08.adoc
+++ b/docs/03-documentation/LZ-3-08.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LZ-3-8]]
-==== LZ 3-8: Architekturentscheidungen erläutern und dokumentieren (R1-R2)
+==== LZ 3-8: Architekturentscheidungen erläutern und dokumentieren (R1,R2)
 
 Softwarearchitekt:innen können:
 
@@ -13,7 +13,7 @@ Softwarearchitekt:innen kennen Architecture-Decision-Records (ADR, siehe <<nygar
 
 // tag::EN[]
 [[LG-3-8]]
-==== LG 3-8: Explain and Document Architectural Decisions (R1-R2)
+==== LG 3-8: Explain and Document Architectural Decisions (R1,R2)
 
 Software architects are able to:
 

--- a/docs/04-quality/LZ-4-3.adoc
+++ b/docs/04-quality/LZ-4-3.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LZ-4-3]]
-==== LZ 4-3: Softwarearchitekturen qualitativ analysieren (R2-R3)
+==== LZ 4-3: Softwarearchitekturen qualitativ analysieren (R2,R3)
 Softwarearchitekt:innen:
 
 * kennen methodische Vorgehensweisen zur qualitativen Analyse von Softwarearchitekturen (R2), beispielsweise nach ATAM (R3)
@@ -18,7 +18,7 @@ Softwarearchitekt:innen:
 
 // tag::EN[]
 [[LG-4-3]]
-==== LG 4-3: Qualitative Analysis of Software Architectures (R2-R3)
+==== LG 4-3: Qualitative Analysis of Software Architectures (R2,R3)
 Software architects:
 
 * know methodical approaches for the qualitative analysis of software architectures (R2), for example, as specified by ATAM (R3);


### PR DESCRIPTION
adapts the learn goal category notation to use comma instead of dash notation

- before change: it is sometimes unclear if the learn goal consists of a collection that covers either R1 or R3, e.g. LG 2-1 or from R1 to R3, e.g. LG 3-2, hence to make it clear (e.g. if R2 is included or not): this change lists all categories explicitly
- after change: uses comma notation only