### PR TITLE
Remove Duplicate Definition

### DIFF
--- a/docs/config/i18n-definitions.adoc
+++ b/docs/config/i18n-definitions.adoc
@@ -1,13 +1,11 @@
 // tag::DE[]
 :learning_goals: Lernziele
-:chapter-label:
 :introduction: Einleitung
 :references: Referenzen
 // end::DE[]
 
 // tag::EN[]
 :learning_goals: Learning Goals
-:chapter-label:
 :introduction: Introduction
 :references: References
 // end::EN[]


### PR DESCRIPTION
`:chapter_labels:` was defined three times, one definition (in `setup.adoc`) is enough. 

close #343 