### PR TITLE
Cleanup overview page

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -6,12 +6,10 @@ include::config/setup.adoc[]
 
 The international Software Architecture Qualification Board (link:https://isaqb.org[iSAQB]) defines curricula on several levels for software architects. You can find download links in the following sections.
 
-The **Foundation Level** curriculum is currently maintained and published in both English (EN) and German (DE). Maintainers from the Foundation-Level-Working-Group and voluntary reviewers collaborate on https://github.com/isaqb-org[Github] to improve the curriculum.
-
-A **glossary** of the terminology used in the iSAQB curricula can be found as a (freely available) ebook, published on https://leanpub.com/isaqbglossary/read[Leanpub]
+The **Foundation Level** curriculum is currently maintained and published in both English (EN) and German (DE). Maintainers from the Foundation-Level-Working-Group and voluntary reviewers collaborate on https://github.com/isaqb-org[GitHub] to improve the curriculum.
 
 == Available Versions
-=== Version 2021.1 (released February 26th, 2021 | valid from April 1st, 2021)
+=== Version 2023.1 (released March 1st, 2023 | valid from April 1st, 2023)
 
 |===
 | Version | HTML | PDF
@@ -39,29 +37,27 @@ A **glossary** of the terminology used in the iSAQB curricula can be found as a 
 |===
 
 
-=== Version 2019.2 (released December 2019, formerly known as V5.1)
-**ATTENTION: This version of the curriculum is only valid up to and including March 31st, 2021.**
+=== Version 2021.1 (released February 26, 2021)
+**ATTENTION: This version of the curriculum is only valid up to and including March 31st, 2023.**
 
 |===
 | Version | PDF
 
 | German
-| https://github.com/isaqb-org/curriculum-foundation/releases/download/2019.2-rev1/foundation-curriculum-de.pdf[Download]
+| https://github.com/isaqb-org/curriculum-foundation/releases/download/2021.1-rev4/curriculum-foundation-de.pdf[Download]
 
 | English
-| https://github.com/isaqb-org/curriculum-foundation/releases/download/2019.2-rev1/foundation-curriculum-en.pdf[Download]
+| https://github.com/isaqb-org/curriculum-foundation/releases/download/2021.1-rev4/foundation-curriculum-en.pdf[Download]
+
+| Spanish
+| https://github.com/isaqb-org/curriculum-foundation/releases/download/2021.1-rev4/foundation-curriculum-es.pdf[Download]
+
+| Italian
+| https://github.com/isaqb-org/curriculum-foundation/releases/download/2021.1-rev4/foundation-curriculum-it.pdf[Download]
+
+| Portuguese
+| https://github.com/isaqb-org/curriculum-foundation/releases/download/2021.1-rev4/foundation-curriculum-pt.pdf[Download]
 
 |===
 
-
-More versions https://github.com/isaqb-org/curriculum-foundation/tags[(tagged) on the Github Releases page.]
-
-== Version 4.x (released 2017)
-
-The previous main releases are version 4.1 (EN) and 4.2 (DE), both of which are only available upon request.
-
-== Versions 3 and prior
-
-iSAQB does not maintain a repository of older versions. Upon request, we can provide previous versions,
-you may volunteer to update this repository accordingly. Thank you.
-
+More versions https://github.com/isaqb-org/curriculum-foundation/tags[(tagged) on the GitHub Releases page.]


### PR DESCRIPTION
- Remove older versions, only 2021 and 2023 are kept.
- Adjust file to show new 2023 release.
- Remove reference to glossary on LeanPub.

close #366 