### PR TITLE
Replace reference for ISO25010 draft with released 25010+25019

### DIFF
--- a/docs/09-references/00-references.adoc
+++ b/docs/09-references/00-references.adoc
@@ -50,7 +50,8 @@
 
 // I
 - [[[isaqbreferences,iSAQB References]]] Gernot Starke et. al. Annotated collection of Software Architecture References, for Foundation and Advanced Level Curricula. Freely available https://leanpub.com/isaqbreferences.
-- [[[iso25010, ISO 25010]]] ISO/IEC DIS 25010:2023(en) Systems and software engineering — Systems and software Quality Requirements and Evaluation (SQuaRE) — Product quality model. Terms and definitions online: <https://www.iso.org/obp/ui/#iso:std:iso-iec:25010:dis:ed-2:v1:en>
+- [[[iso25010, ISO 25010]]] ISO/IEC 25010:2023(en) Systems and software engineering — Systems and software Quality Requirements and Evaluation (SQuaRE) — Product quality model. Terms and definitions online: <https://www.iso.org/obp/ui/#iso:std:iso-iec:25010:ed-2:v1:en>
+- [[[iso25019, ISO 25019]]] ISO/IEC 25019:2023(en) Systems and software engineering — Systems and software Quality Requirements and Evaluation (SQuaRE) — Quality-in-use model. Terms and definitions online: <https://www.iso.org/obp/ui/#iso:std:iso-iec:25019:ed-1:v1:en>
 - [[[iso42010,ISO 42010]]] ISO/IEC/IEEE 42010:2022, Software, systems and enterprise Architecture description, online: <https://www.iso.org/standard/74393.html>
 
 // K


### PR DESCRIPTION
 - ISO25010:2023 has been released
 - added ISO25019:2023 because parts of the old norm ended up there and quality-in-use is relevant as well