### PR TITLE
Fix Chapter Names

### DIFF
--- a/docs/config/setup.adoc
+++ b/docs/config/setup.adoc
@@ -39,18 +39,6 @@ endif::[]
 // but the "BIB_REFS" tag.
 :bibrefs: BIB_REFS
 
-// you might want to output some internal information...
-ifdef::debug_adoc[]
-[NOTE]
-====
-Current configuration:
-
-* Language(s): {language}
-* Document version: {document-version}
-* Include-configuration: {include_configuration}
-====
-endif::debug_adoc[]
-
 // glossary definitions
 // iSAQB maintains and publishes a "Glossary of Software Architecture Terminology"
 // on github (https://public.isaqb.org/glossary)

--- a/docs/config/setup.adoc
+++ b/docs/config/setup.adoc
@@ -1,7 +1,7 @@
 :doctype: book
 :icons: font
 :sectnumlevels: 1
-:chapter-label: 
+:!chapter-signifier:
 :imagesdir: ./images
 :figure-caption!:
 


### PR DESCRIPTION
We decided years ago that we do not want to use `Chapter 1 This is Chapter One / Kapitel 1 Dies ist Kapitel eins` but want to name the chapters as follows:
`1 This is Chapter One / 1 Dies ist Kapitel eins`

By using the proper configuration key, we achieve this. 🙂 

close #536 

