### PR TITLE
Create Section for References

### DIFF
--- a/docs/01-basics/01-basics-duration-terms.adoc
+++ b/docs/01-basics/01-basics-duration-terms.adoc
@@ -15,20 +15,20 @@ Außerdem wird deren Rolle im organisatorischen Kontext und ihre Interaktion mit
 
 === Wesentliche Begriffe
 {glossary_url}software-architecture[Softwarearchitektur];
-Architekturdomänen; 
-{glossary_url}structure[Struktur]; 
-{glossary_url}building-block[Bausteine]; 
-{glossary_url}component[Komponenten]; 
-{glossary_url}interface[Schnittstellen]; 
-{glossary_url}relationship[Beziehungen]; 
+Architekturdomänen;
+{glossary_url}structure[Struktur];
+{glossary_url}building-block[Bausteine];
+{glossary_url}component[Komponenten];
+{glossary_url}interface[Schnittstellen];
+{glossary_url}relationship[Beziehungen];
 {glossary_url}cross-cutting-concern[Querschnittsthemen];
-Nutzen von Softwarearchitektur; 
-Softwarearchitekt:innen und deren Verantwortlichkeiten; 
-Rolle; 
-Aufgaben und benötigte Fähigkeiten; 
-Stakeholder und deren Anliegen; 
-Anforderungen; 
-{glossary_url}constraints[Randbedingungen]; 
+Nutzen von Softwarearchitektur;
+Softwarearchitekt:innen und deren Verantwortlichkeiten;
+Rolle;
+Aufgaben und benötigte Fähigkeiten;
+Stakeholder und deren Anliegen;
+Anforderungen;
+{glossary_url}constraint[Randbedingungen];
 Einflussfaktoren
 
 // end::DE[]
@@ -48,18 +48,18 @@ Furthermore, they will be able to name and explain the most important tasks and 
 Additionally, the section explores the role of software architects in the broader architectural context and their interactions with other stakeholders, preparing participants to effectively contribute to diverse software development projects.
 
 === Relevant Terms
-{glossary_url}software-architecture[Software architecture]; 
-architecture domains; {glossary_url}structure[structure]; 
-{glossary_url}building-block[building blocks]; 
-{glossary_url}component[components]; 
-{glossary_url}interface[interfaces]; 
-{glossary_url}relationship[relationships]; 
+{glossary_url}software-architecture[Software architecture];
+architecture domains; {glossary_url}structure[structure];
+{glossary_url}building-block[building blocks];
+{glossary_url}component[components];
+{glossary_url}interface[interfaces];
+{glossary_url}relationship[relationships];
 {glossary_url}cross-cutting-concern[cross-cutting concerns];
-software architects and their responsibilities; 
-tasks and required skills; 
-stakeholders and their concerns; 
+software architects and their responsibilities;
+tasks and required skills;
+stakeholders and their concerns;
 requirements;
-{glossary_url}constraints[constraints]; 
+{glossary_url}constraint[constraints];
 influencing factors
 
 // end::EN[]

--- a/docs/01-basics/LZ-01-01.adoc
+++ b/docs/01-basics/LZ-01-01.adoc
@@ -2,14 +2,17 @@
 // tag::DE[]
 [[LG-01-01]]
 ==== LZ 01-01: Definitionen von Softwarearchitektur diskutieren (R1)
-Softwarearchitekt:innen kennen die Gemeinsamkeiten vieler Definitionen
-von Softwarearchitektur <<iso42010>> <<bass>> <<kruchten>>:
+
+Softwarearchitekt:innen kennen die Gemeinsamkeiten vieler Definitionen von Softwarearchitektur :
 
 * {glossary_url}building-block[Komponenten/Bausteine] mit Schnittstellen und Beziehungen
 * Bausteine als allgemeiner Begriff, Komponenten als eine spezielle Ausprägung davon
 * Strukturen, {glossary_url}cross-cutting-concern[Querschnittsthemen], Prinzipien
 * Architekturentscheidungen und ihre Auswirkungen auf das gesamte System und
   seinen Lebenszyklus
+
+===== Quellen
+<<iso42010>> <<bass>> <<kruchten>>
 
 // end::DE[]
 

--- a/docs/01-basics/LZ-01-01.adoc
+++ b/docs/01-basics/LZ-01-01.adoc
@@ -1,4 +1,3 @@
-
 // tag::DE[]
 [[LG-01-01]]
 ==== LZ 01-01: Definitionen von Softwarearchitektur diskutieren (R1)
@@ -11,17 +10,13 @@ Softwarearchitekt:innen kennen die Gemeinsamkeiten vieler Definitionen von Softw
 * Architekturentscheidungen und ihre Auswirkungen auf das gesamte System und
   seinen Lebenszyklus
 
-===== Quellen
-<<iso42010>> <<bass>> <<kruchten>>
-
 // end::DE[]
 
 // tag::EN[]
 [[LG-01-01]]
 ==== LG 01-01: Discuss Definitions of Software Architecture (R1)
 
-Software architects know the commonalities of many definitions of
-software architecture <<iso42010>> <<bass>> <<kruchten>>:
+Software architects know the commonalities of many definitions of software architecture:
 
 * {glossary_url}building-block[components/building blocks] with interfaces and relationships
 * building blocks as a general term, components as a special form thereof
@@ -29,3 +24,6 @@ software architecture <<iso42010>> <<bass>> <<kruchten>>:
 * architecture decisions and their consequences on the entire systems and its lifecycle
 
 // end::EN[]
+
+===== {references}
+<<iso42010>>, <<bass>>, <<kruchten>>

--- a/docs/01-basics/LZ-01-01.adoc
+++ b/docs/01-basics/LZ-01-01.adoc
@@ -2,7 +2,7 @@
 [[LG-01-01]]
 ==== LZ 01-01: Definitionen von Softwarearchitektur diskutieren (R1)
 
-Softwarearchitekt:innen kennen die Gemeinsamkeiten vieler Definitionen von Softwarearchitektur :
+Softwarearchitekt:innen kennen die Gemeinsamkeiten vieler Definitionen von Softwarearchitektur:
 
 * {glossary_url}building-block[Komponenten/Bausteine] mit Schnittstellen und Beziehungen
 * Bausteine als allgemeiner Begriff, Komponenten als eine spezielle Ausprägung davon

--- a/docs/02-requirements/LZ-02-04.adoc
+++ b/docs/02-requirements/LZ-02-04.adoc
@@ -7,7 +7,7 @@ Softwarearchitekt:innen:
 
 * können Szenarien für gegebene Qualitäten mit Kontext, Stimulus und Reaktion oder Messmethode formulieren <<bass>> (R1)
 * verstehen, dass eine Anforderung für eine gegebene Qualität
-  eine Analysemethode spezifizieren sollte (siehe <<LZ-05-02>>) (R1)
+  eine Analysemethode spezifizieren sollte (siehe <<LG-05-02>>) (R1)
 * wissen, dass die Verwendung einer Metrik als Ziel diese invalidieren kann (R2), wie z.{nbsp}B. in Goodhart's Law (R3) beschrieben
 
 // end::DE[]

--- a/docs/config/setup.adoc
+++ b/docs/config/setup.adoc
@@ -31,7 +31,7 @@ endif::[]
 
 // ":include_configuration:" always consists of the language,
 // additional markers might be configured here!
-:include_configuration: tags={language}
+:include_configuration: tags=!*;{language}
 
 
 // ":bibrefs:" (bibliography entries) are single language, to avoid redundancy.

--- a/docs/config/setup.adoc
+++ b/docs/config/setup.adoc
@@ -33,12 +33,6 @@ endif::[]
 // additional markers might be configured here!
 :include_configuration: tags=!*;{language}
 
-
-// ":bibrefs:" (bibliography entries) are single language, to avoid redundancy.
-// therefore the appropriate include statements don't contain a language,
-// but the "BIB_REFS" tag.
-:bibrefs: BIB_REFS
-
 // glossary definitions
 // iSAQB maintains and publishes a "Glossary of Software Architecture Terminology"
 // on github (https://public.isaqb.org/glossary)


### PR DESCRIPTION
- Demonstrate how every (!) learning goal has to define its own references section
- Fix configuration to also include text that is not enclosed in language tags
- Remove bibref variable to trigger warnings: Once every learning goal of a chapter has its own references section, the references file causing the warning has to be removed. 
- Fix broken reference to glossary
- Fix broken learning goal reference


See #535 