### PR TITLE
Separate out "data handling" from "data modeling".

### DIFF
--- a/docs/01-basics/LG-01-07.adoc
+++ b/docs/01-basics/LG-01-07.adoc
@@ -1,31 +1,29 @@
 
 // tag::DE[]
 [[LG-01-07]]
-==== LZ 01-07: Bedeutung von Daten und Datenmodellen (R2)
+==== LZ 01-07: Bedeutung von Datenmodellen (R2)
 
-Softwarearchitekt:innen verstehen die Bedeutung von Daten und Datenmodellen für die Architektur.  
+Softwarearchitekt:innen verstehen die Bedeutung von Datenmodellen für die Architektur.  
 Sie
 
 * können Datenmodelle identifizieren, die maßgeblichen Einfluss auf die Architektur haben. 
 * können solche Datenmodelle systematisch entwerfen. 
 * verstehen den Unterschied zwischen {glossary_url}product[Produkten] und {glossary_url}sum[Summen] in der Datenmodellierung.
 * verstehen die Bedeutung der Entkopplung von Datenmodellen und ihrer Repräsentation in Datenbanken, Dateien und Übertragungsprotokollen. 
-* können die Auswirkungen von Daten auf Architekturentscheidungen z.B. in Bezug auf Speicherung, Sicherheit, Skalierbarkeit, Zuverlässigkeit, Performance usw. erläutern. 
 
 // end::DE[]
 
 // tag::EN[]
 [[LG-01-07]]
-==== LG 01-07: Importance of Data and Data Models (R2)
+==== LG 01-07: Importance of Data Models (R2)
 
-Software architects understand the importance of data and data models for the architecture.  
+Software architects understand the importance of data models for the architecture.  
 They
 
 * can identify data models that have significant impact on the  architecture. 
 * can design such data models systematically. 
 * understand the difference between {glossary_url}product[products] and {glossary_url}sum[sums] in data modelling.
 * understand the importance of decoupling data models from their representation in databases, files, and transmission protocols.
-* can explain the impact of data on architecture decisions regarding e.g. storage, security, scalability, reliability, performance etc.
 
 // end::EN[]
 

--- a/docs/03-design/00-design.adoc
+++ b/docs/03-design/00-design.adoc
@@ -30,3 +30,5 @@ include::./LG-03-11.adoc[{include_configuration}]
 
 include::./LG-03-12.adoc[{include_configuration}]
 
+include::./LG-03-13.adoc[{include_configuration}]
+

--- a/docs/03-design/LG-03-11.adoc
+++ b/docs/03-design/LG-03-11.adoc
@@ -1,37 +1,24 @@
 
 // tag::DE[]
-
 [[LG-03-11]]
-==== LZ 03-11 [ehemaliges LZ 2-10]: Grundlegende Prinzipien von Software-Deployments kennen (R3)
-Softwarearchitekt:innen:
+==== LZ 03-11: Bedeutung vom Umgang mit Daten (R2)
 
-* wissen, dass Software-Deployment der Prozess ist, durch den neue oder aktualisierte Software zur Benutzung bereitgestellt wird
-* können grundlegende Konzepte des Deployments von Software benennen und erklären:
-** Automatisierung von Deployments
-** Wiederholbare Builds
-** Konsistente Umgebungen (z.{nbsp}B. durch Nutzung von unveränderlicher (_immutable_) Infrastruktur)
-** Alles liegt unter Versionskontrolle
-** Releases sind einfach zurückzunehmen
+Softwarearchitekt:innen verstehen die Bedeutung vom Umgang mit Daten für die Architektur.  
+Sie
+
+* können erläutern, wie sich Architekturentscheidungen zum Umgang mit Daten auf Qualitäten wie Integrität, Vertraulichkeit, Skalierbarkeit, Zuverlässigkeit und Performance auswirken.
+* können Architekturentscheidungen treffen, um Anforderungen an diese Qualitäten zu erfüllen.
 
 // end::DE[]
 
 // tag::EN[]
-
 [[LG-03-11]]
-==== LG 03-11 [previously LG 2-10]: Know Fundamental Principles of Software Deployment (R3)
+==== LG 03-11: Importance of Data Handling (R2)
 
-Software architects:
+Software architects understand the importance of the handling of data for the architecture.
+They
 
-* know that software deployment is the process of making new or updated software available to its users
-* are able to name and explain fundamental concepts of software deployment:
-** automated deployments
-** repeatable builds
-** consistent environments (e.g. use immutable and disposable infrastructure)
-** put everything under version-control
-** releases are easy-to-undo
-
+* can explain how architectural decisions regarding the handling of data impact qualities such as integrity, confidentiality, scalability, reliability, and performance.
+* can make architectural decisions to meet requirements on these properties.
 
 // end::EN[]
-
-===== {references}
-<<humble>>

--- a/docs/03-design/LG-03-12.adoc
+++ b/docs/03-design/LG-03-12.adoc
@@ -1,39 +1,37 @@
 
 // tag::DE[]
+
 [[LG-03-12]]
-==== LZ 03-12 [ehemaliges LZ 1-11]: Herausforderungen verteilter Systeme kennen (R3)
+==== LZ 03-12 [ehemaliges LZ 2-10]: Grundlegende Prinzipien von Software-Deployments kennen (R3)
+Softwarearchitekt:innen:
 
-Softwarearchitekt:innen können:
+* wissen, dass Software-Deployment der Prozess ist, durch den neue oder aktualisierte Software zur Benutzung bereitgestellt wird
+* können grundlegende Konzepte des Deployments von Software benennen und erklären:
+** Automatisierung von Deployments
+** Wiederholbare Builds
+** Konsistente Umgebungen (z.{nbsp}B. durch Nutzung von unveränderlicher (_immutable_) Infrastruktur)
+** Alles liegt unter Versionskontrolle
+** Releases sind einfach zurückzunehmen
 
-* die Verteilung in einer gegebenen Software-Architektur identifizieren
-* Konsistenzkriterien für ein gegebenes fachliches Problem analysieren
-* Kausalität von Ereignissen in einem verteilten System erklären
-
-Softwarearchitekt:innen wissen:
-
-* dass Kommunikation in einem verteilten System fehlschlagen kann
-* dass es bei verteilten Systemen Einschränkungen hinsichtlich der Konsistenz in Datenbanken gibt
-* was das "Split-Brain"-Problem ist und warum es schwierig zu lösen ist
-* dass es unmöglich ist, die exakte zeitliche Reihenfolge der Ereignisse in einem verteilten System zu bestimmen
 // end::DE[]
 
 // tag::EN[]
+
 [[LG-03-12]]
-==== LG 03-12 [previously LG 1-11]: Know the Challenges of Distributed Systems (R3)
+==== LG 03-12 [previously LG 2-10]: Know Fundamental Principles of Software Deployment (R3)
 
-Software architects are able to:
+Software architects:
 
-* identify distribution in a given software architecture
-* analyze consistency criteria for a given business problem
-* explain causality of events in a distributed system
+* know that software deployment is the process of making new or updated software available to its users
+* are able to name and explain fundamental concepts of software deployment:
+** automated deployments
+** repeatable builds
+** consistent environments (e.g. use immutable and disposable infrastructure)
+** put everything under version-control
+** releases are easy-to-undo
 
-Software architects know:
 
-* communication may fail in a distributed system
-* limitations regarding consistency in real-world databases
-* what the "split-brain" problem is and why it is difficult
-* that it is impossible to determine the temporal order of events in a distributed system
 // end::EN[]
 
 ===== {references}
-<<distributedsystems>>, <<buschmannb>>, <<fordhardparts>>, <<miller-distributed>>
+<<humble>>

--- a/docs/03-design/LG-03-13.adoc
+++ b/docs/03-design/LG-03-13.adoc
@@ -1,0 +1,39 @@
+
+// tag::DE[]
+[[LG-03-13]]
+==== LZ 03-13 [ehemaliges LZ 1-11]: Herausforderungen verteilter Systeme kennen (R3)
+
+Softwarearchitekt:innen können:
+
+* die Verteilung in einer gegebenen Software-Architektur identifizieren
+* Konsistenzkriterien für ein gegebenes fachliches Problem analysieren
+* Kausalität von Ereignissen in einem verteilten System erklären
+
+Softwarearchitekt:innen wissen:
+
+* dass Kommunikation in einem verteilten System fehlschlagen kann
+* dass es bei verteilten Systemen Einschränkungen hinsichtlich der Konsistenz in Datenbanken gibt
+* was das "Split-Brain"-Problem ist und warum es schwierig zu lösen ist
+* dass es unmöglich ist, die exakte zeitliche Reihenfolge der Ereignisse in einem verteilten System zu bestimmen
+// end::DE[]
+
+// tag::EN[]
+[[LG-03-13]]
+==== LG 03-13 [previously LG 1-11]: Know the Challenges of Distributed Systems (R3)
+
+Software architects are able to:
+
+* identify distribution in a given software architecture
+* analyze consistency criteria for a given business problem
+* explain causality of events in a distributed system
+
+Software architects know:
+
+* communication may fail in a distributed system
+* limitations regarding consistency in real-world databases
+* what the "split-brain" problem is and why it is difficult
+* that it is impossible to determine the temporal order of events in a distributed system
+// end::EN[]
+
+===== {references}
+<<distributedsystems>>, <<buschmannb>>, <<fordhardparts>>, <<miller-distributed>>


### PR DESCRIPTION
Relates to #660.

Note that this also moves "data handling" to a more appropriate place. I don't know how amenable we are to changing the section numbering - but I figured I'd start by putting it in the place I considered best.