### PR TITLE
Indicate (R1, R3) instead (R1-R3) for LG 02-01

### DIFF
--- a/docs/02-requirements/LG-02-01.adoc
+++ b/docs/02-requirements/LG-02-01.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-02-01]]
-==== LZ 02-01: Stakeholder-Anliegen verstehen (R1-R3)
+==== LZ 02-01: Stakeholder-Anliegen verstehen (R1, R3)
 
 Architekten können Stakeholder und deren Anliegen sowie deren Auswirkungen auf die Softwarearchitektur oder den Entwurfs- und Entwicklungsprozess identifizieren. (R1)
 
@@ -41,7 +41,7 @@ Architekt:innen können die Anliegen der Stakeholder nutzen, um fehlende oder wi
 
 // tag::EN[]
 [[LG-02-01]]
-==== LG 02-01: Understand Stakeholder Concerns (R1-R3)
+==== LG 02-01: Understand Stakeholder Concerns (R1,R3)
 
 Architects can identify stakeholders and their concerns, as well as their impact on the software architecture or the design and development process. (R1)
 


### PR DESCRIPTION
... as there are no more R2 parts inside, and for the sake of consistency with the other LGs