### PR TITLE
#730 moved remote procedure call (RPC) from Design Patterns (LG 03.08…

### DIFF
--- a/docs/03-design/LG-03-08.adoc
+++ b/docs/03-design/LG-03-08.adoc
@@ -17,6 +17,7 @@ Softwarearchitekt:innen können einige der folgendene Muster erklären, ihre Rel
 * {glossary_url}event-sourcing[Event sourcing]
 * {glossary_url}dependency-injection[Dependency Injection] (siehe auch <<LG-03-06>>)
 * Integrations und Messaging-Patterns (z.B. aus <<hohpe>>)
+* {glossary_url}remote-procedure-call[Remote procedure call]
 * {glossary_url}model-view-controller[MVC] (Model View Controller),
   {glossary_url}model-view-viewmodel[MVVM] (Model View ViewModel),
   {glossary_url}model-view-update[MVU] (Model View Update),
@@ -49,6 +50,7 @@ explain their relevance for concrete systems, and provide examples. (R3)
 * {glossary_url}event-sourcing[Event sourcing]
 * {glossary_url}dependency-injection[Dependency Injection] (see also <<LG-03-06>>)
 * Integration and messaging patterns (e.g. from <<hohpe>>)
+* {glossary_url}remote-procedure-call[Remote procedure call]
 * {glossary_url}model-view-controller[MVC] (Model View Controller),
   {glossary_url}model-view-viewmodel[MVVM] (Model View ViewModel),
   {glossary_url}model-view-update[MVU] (Model View Update),

--- a/docs/03-design/LG-03-09.adoc
+++ b/docs/03-design/LG-03-09.adoc
@@ -13,8 +13,7 @@ Sie können mehrere der folgenden Entwurfsmuster beschreiben, ihre Relevanz für
   Programmiersprachen oder Frameworks verwendet werden können.
 * {glossary_url}interpreter[Interpreter]
 * {glossary_url}observer[Observer]
-* {glossary_url}remote-procedure-call[Remote procedure call]
-* {glossary_url}template-method[Template Method] und {glossary_url}Strategy[Strategy]
+* {glossary_url}template-method[Template Method] und {glossary_url}strategy[Strategy]
 * {glossary_url}visitor[Visitor]
 
 Softwarearchitekt:innen kennen wesentliche Quellen für Entwurfsmuster, wie z.B.
@@ -43,8 +42,7 @@ They can describe several of the following design patterns, explain their releva
   independently of a particular programming language or framework.
 * {glossary_url}interpreter[Interpreter]
 * {glossary_url}observer[Observer]
-* {glossary_url}remote-procedure-call[Remote procedure call]
-* {glossary_url}template-method[Template Method] and {glossary_url}Strategy[Strategy]
+* {glossary_url}template-method[Template Method] and {glossary_url}strategy[Strategy]
 * {glossary_url}visitor[Visitor]
 
 Software architects know essential sources for design patterns, such as


### PR DESCRIPTION
…) to Architectural Patterns (LG 03.09.), fixed reference typo for glossary term "strategy"