### PR TITLE
LG-3-09 removed the distinction between architecture and design patte…

### DIFF
--- a/docs/03-design/LG-03-08.adoc
+++ b/docs/03-design/LG-03-08.adoc
@@ -28,6 +28,13 @@ Softwarearchitekt:innen können einige der folgendene Muster erklären, ihre Rel
 
 Softwarearchitekt:innen kennen wesentliche Quellen für Architekturmuster, beispielsweise die POSA-Literatur (z.{nbsp}B. <<buschmanna>>) und PoEAA (<<fowler>>) (für Informationssysteme). (R3)
 
+
+Sie wissen:
+
+* dass Muster ein Weg sind, bestimmte Qualitäten für gegebene Probleme und Anforderungen innerhalb gegebener Kontexte zu erreichen.
+* dass es verschiedene Kategorien von Mustern gibt.
+* zusätzliche Quellen für Muster, die sich auf ihre spezifische technische oder Anwendungsdomäne beziehen.
+
 // end::DE[]
 
 // tag::EN[]
@@ -61,6 +68,11 @@ explain their relevance for concrete systems, and provide examples. (R3)
 
 Software architects know essential sources for architectural patterns, such as POSA (e.g. <<buschmanna>>) and PoEAA (<<fowler>>) (for information systems). (R3)
 
+They know:
+
+* that patterns are a way of achieving certain qualities for given problems and requirements within given contexts.
+* that there are different categories of patterns.
+* additional sources of patterns that relate to their specific technical or application domain.
 // end::EN[]
 
 ===== {references}

--- a/docs/03-design/LG-03-09.adoc
+++ b/docs/03-design/LG-03-09.adoc
@@ -3,8 +3,7 @@
 [[LG-03-09]]
 ==== LZ 03-09 [ehemaliges LZ 2-05]: Wichtige Entwurfsmuster beschreiben, erklären und angemessen anwenden (R3)
 
-Softwarearchitekt:innen kennen den Unterschied zwischen Architektur- und Entwurfsmustern.
-Sie können mehrere der folgenden Entwurfsmuster beschreiben, ihre Relevanz für die Architektur und konkrete Systeme erklären sowie Beispiele nennen. 
+Softwarearchitekt:innen können mehrere der folgenden Entwurfsmuster beschreiben, ihre Relevanz für die Architektur und konkrete Systeme erklären sowie Beispiele nennen. 
 
 * {glossary_url}combinator[Combinator]
 * Schnittstellenmuster wie {glossary_url}adapter[Adapter], {glossary_url}facade[Facade],
@@ -19,11 +18,6 @@ Sie können mehrere der folgenden Entwurfsmuster beschreiben, ihre Relevanz für
 Softwarearchitekt:innen kennen wesentliche Quellen für Entwurfsmuster, wie z.B.
 <<gof,GOF>> und <<buschmanna,POSA>>.
 
-Sie wissen:
-
-* dass Muster ein Weg sind, bestimmte Qualitäten für gegebene Probleme und Anforderungen innerhalb gegebener Kontexte zu erreichen.
-* dass es verschiedene Kategorien von Mustern gibt.
-* zusätzliche Quellen für Muster, die sich auf ihre spezifische technische oder Anwendungsdomäne beziehen.
 
 // end::DE[]
 
@@ -32,8 +26,7 @@ Sie wissen:
 
 ==== LG 03-09 [previously LG 2-05]: Describe, Explain, and Appropriately Apply Important Design Patterns (R3)
 
-Software architects know the difference between architectural and design patterns.
-They can describe several of the following design patterns, explain their relevance for the architecture and specific systems and give examples. 
+Software can describe several of the following design patterns, explain their relevance for the architecture and specific systems and give examples. 
 
 * {glossary_url}combinator[Combinator]
 * Interfacing patterns like {glossary_url}adapter[Adapter], {glossary_url}facade[Facade],
@@ -48,11 +41,7 @@ They can describe several of the following design patterns, explain their releva
 Software architects know essential sources for design patterns, such as
 <<gof,GOF>> and <<buschmanna,POSA>>.
 
-They know:
 
-* that patterns are a way of achieving certain qualities for given problems and requirements within given contexts.
-* that there are different categories of patterns.
-* additional sources of patterns that relate to their specific technical or application domain.
 
 // end::EN[]
 


### PR DESCRIPTION
as discussed here https://github.com/isaqb-org/curriculum-foundation/pull/732#issuecomment-2669127772

removed the distinction of architecture and design patterns 

Moved explanatory paragraph from 3-9 to 3-8