### PR TITLE
Handle References to Old LGs Consistently

### DIFF
--- a/docs/01-basics/LG-01-05.adoc
+++ b/docs/01-basics/LG-01-05.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-01-05]]
-==== LZ 01-05 [ehemaliges LZ 1-09]: Abgrenzung zu anderen Architekturdomänen (R3)
+==== LZ 01-05 [ehemaliges LZ 1-9]: Abgrenzung zu anderen Architekturdomänen (R3)
 
 Der Fokus des iSAQB CPSA-Foundation Level liegt auf Strukturen und Konzepten einzelner Softwaresysteme.
 
@@ -20,7 +20,7 @@ Diese Architekturdomänen sind nicht inhaltlicher Fokus vom CPSA-F.
 
 // tag::EN[]
 [[LG-01-05]]
-==== LG 01-05 [previously LG 1-09]: Distinction between Software Architecture and other Architectural Domains (R3)
+==== LG 01-05 [previously LG 1-9]: Distinction between Software Architecture and other Architectural Domains (R3)
 
 The focus of the iSAQB CPSA Foundation Level is on structures and concepts of individual software systems.
 

--- a/docs/02-requirements/LG-02-04.adoc
+++ b/docs/02-requirements/LG-02-04.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-02-04]]
-==== LZ 02-04 [ehemaliges LZ 04-02]: Anforderungen an Qualitäten formulieren (R1-R3)
+==== LZ 02-04 [ehemaliges LZ 4-2]: Anforderungen an Qualitäten formulieren (R1-R3)
 
 Softwarearchitekt:innen:
 
@@ -15,7 +15,7 @@ Softwarearchitekt:innen:
 
 // tag::EN[]
 [[LG-02-04]]
-==== LG 02-04 [previously LG 04-02]: Formulate Requirements on Qualities (R1-R3)
+==== LG 02-04 [previously LG 4-2]: Formulate Requirements on Qualities (R1-R3)
 
 Software architects:
 

--- a/docs/02-requirements/LG-02-05.adoc
+++ b/docs/02-requirements/LG-02-05.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-02-05]]
-==== LZ 02-05 [ehemaliges LZ 1-08]: Explizite Aussagen vor impliziten Annahmen bevorzugen (R1)
+==== LZ 02-05 [ehemaliges LZ 1-8]: Explizite Aussagen vor impliziten Annahmen bevorzugen (R1)
 
 Softwarearchitekt:innen:
 
@@ -12,7 +12,7 @@ Softwarearchitekt:innen:
 
 // tag::EN[]
 [[LG-02-05]]
-==== LG 02-05 [previously LG 1-08]: Prefer Explicit Statements over Implicit Assumptions (R1)
+==== LG 02-05 [previously LG 1-8]: Prefer Explicit Statements over Implicit Assumptions (R1)
 
 Software architects:
 

--- a/docs/03-design/LG-03-02.adoc
+++ b/docs/03-design/LG-03-02.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-03-02]]
-==== LZ 03-02 [ehemaliges LZ 2-02]: Softwarearchitekturen entwerfen (R1)
+==== LZ 03-02 [ehemaliges LZ 2-2]: Softwarearchitekturen entwerfen (R1)
 
 Softwarearchitekt:innen können:
 
@@ -19,7 +19,7 @@ Softwarearchitekt:innen können:
 
 // tag::EN[]
 [[LG-03-02]]
-==== LG 03-02 [previously LG 2-02]: Design Software Architectures (R1)
+==== LG 03-02 [previously LG 2-2]: Design Software Architectures (R1)
 
 Software architects are able to:
 

--- a/docs/03-design/LG-03-03.adoc
+++ b/docs/03-design/LG-03-03.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-03-03]]
-==== LZ 03-03 [ehemaliges LZ 2-01]: Vorgehen und Heuristiken zur Architekturentwicklung auswählen und anwenden können (R1,R3)
+==== LZ 03-03 [ehemaliges LZ 2-1]: Vorgehen und Heuristiken zur Architekturentwicklung auswählen und anwenden können (R1,R3)
 
 Softwarearchitekt:innen können grundlegende Vorgehensweisen der Architekturentwicklung benennen, erklären und anwenden, beispielsweise:
 
@@ -16,7 +16,7 @@ Softwarearchitekt:innen können grundlegende Vorgehensweisen der Architekturentw
 
 // tag::EN[]
 [[LG-03-03]]
-==== LG 03-03 [previously LG 2-01]: Select and Use Approaches and Heuristics for Architecture Development (R1,R3)
+==== LG 03-03 [previously LG 2-1]: Select and Use Approaches and Heuristics for Architecture Development (R1,R3)
 Software architects are able to name, explain, and use fundamental approaches of architecture development, for example:
 
 * top-down and bottom-up approaches to design, see <<gharbietal>>, <<starke>> (R1)

--- a/docs/03-design/LG-03-04.adoc
+++ b/docs/03-design/LG-03-04.adoc
@@ -1,7 +1,7 @@
 // tag::DE[]
 
 [[LG-03-04]]
-==== LZ 03-04 [ehemaliges LZ 2-06]: Entwurfsprinzipien erläutern und anwenden (R1-R3)
+==== LZ 03-04 [ehemaliges LZ 2-6]: Entwurfsprinzipien erläutern und anwenden (R1-R3)
 
 Softwarearchitekt:innen sind in der Lage zu erklären, was Entwurfsprinzipien sind.
 Sie können deren grundlegende Ziele und deren Anwendung im Hinblick auf Softwarearchitektur skizzieren. (R2)
@@ -57,7 +57,7 @@ Single Responsibility Principle, Open/Closed Principle, Liskov Substitution Prin
 // tag::EN[]
 
 [[LG-03-04]]
-==== LG 03-04 [previously LG 2-06]: Explain and Use Design Principles (R2)
+==== LG 03-04 [previously LG 2-6]: Explain and Use Design Principles (R2)
 
 Software architects are able to explain what design principles are.
 They can outline their general objectives and their application with regard to software architecture. (R2)

--- a/docs/03-design/LG-03-05.adoc
+++ b/docs/03-design/LG-03-05.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-03-05]]
-==== LZ 03-05 [ehemaliges LZ 1-06]: Zusammenhang zwischen Feedback-Schleifen und Risiko (R1, R2)
+==== LZ 03-05 [ehemaliges LZ 1-6]: Zusammenhang zwischen Feedback-Schleifen und Risiko (R1, R2)
 
 Softwarearchitekt:innen verstehen die Notwendigkeit von Iterationen, insbesondere bei unter Unsicherheit getroffenen Entscheidungen.
 Sie
@@ -15,7 +15,7 @@ Sie
 
 // tag::EN[]
 [[LG-03-05]]
-==== LG 03-05 [previously LG 1-06]: Correlation between Feedback Loops and Risks (R1, R2)
+==== LG 03-05 [previously LG 1-6]: Correlation between Feedback Loops and Risks (R1, R2)
 
 Software architects understand the necessity of iterations, especially when decisions are made in the face of uncertainties. They
 

--- a/docs/03-design/LG-03-06.adoc
+++ b/docs/03-design/LG-03-06.adoc
@@ -1,7 +1,7 @@
 // tag::DE[]
 
 [[LG-03-06]]
-==== LZ 03-06 [ehemaliges LZ 2-07]: Abhängigkeiten von Bausteinen managen (R1)
+==== LZ 03-06 [ehemaliges LZ 2-7]: Abhängigkeiten von Bausteinen managen (R1)
 
 Softwarearchitekt:innen verstehen Abhängigkeiten und Kopplung zwischen Bausteinen und können diese gezielt einsetzen.
 Sie:
@@ -27,7 +27,7 @@ Sie:
 
 // tag::EN[]
 [[LG-03-06]]
-==== LG 03-06 [previously LG 2-07]: Manage Dependencies between Building Blocks (R1)
+==== LG 03-06 [previously LG 2-7]: Manage Dependencies between Building Blocks (R1)
 
 Software architects understand dependencies and coupling between building blocks and can use them in a targeted manner. They:
 

--- a/docs/03-design/LG-03-07.adoc
+++ b/docs/03-design/LG-03-07.adoc
@@ -2,7 +2,7 @@
 // tag::DE[]
 
 [[LG-03-07]]
-==== LZ 03-07 [ehemaliges LZ 2-09]: Schnittstellen entwerfen und spezifizieren (R1-R3)
+==== LZ 03-07 [ehemaliges LZ 2-9]: Schnittstellen entwerfen und spezifizieren (R1-R3)
 
 Softwarearchitekt:innen kennen die kritische Bedeutung von Schnittstellen für die Interaktion zwischen Architekturbausteinen oder zwischen dem System und externen Elementen. 
 Sie können solche Schnittstellen entwerfen und spezifizieren.
@@ -39,7 +39,7 @@ Siehe auch <<LG-04-06>>.
 
 // tag::EN[]
 [[LG-03-07]]
-==== LG 03-07 [previously LG 2-09]: Design and Define Interfaces (R1-R3)
+==== LG 03-07 [previously LG 2-9]: Design and Define Interfaces (R1-R3)
 
 Software architects know the critical importance of interfaces for the interaction between architectural building blocks or between the system and external elements. 
 They can design and specify such interfaces.

--- a/docs/03-design/LG-03-08.adoc
+++ b/docs/03-design/LG-03-08.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-03-08]]
-==== LZ 03-08 [ehemaliges LZ 2-05]: Wichtige Architekturmuster beschreiben, erklären und angemessen anwenden (R1, R3)
+==== LZ 03-08 [ehemaliges LZ 2-5]: Wichtige Architekturmuster beschreiben, erklären und angemessen anwenden (R1, R3)
 
 Softwarearchitekt:innen können die folgenden Architekturmuster erklären und Beispiele dafür liefern (R1):
 
@@ -40,7 +40,7 @@ Sie wissen:
 // tag::EN[]
 [[LG-03-08]]
 
-==== LG 03-08 [previously LG 2-05]: Describe, Explain and Apply Important Architectural Patterns (R1, R3)
+==== LG 03-08 [previously LG 2-5]: Describe, Explain and Apply Important Architectural Patterns (R1, R3)
 
 Software architects can explain and provide examples for the following architectural patterns (R1):
 

--- a/docs/03-design/LG-03-09.adoc
+++ b/docs/03-design/LG-03-09.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-03-09]]
-==== LZ 03-09 [ehemaliges LZ 2-05]: Wichtige Entwurfsmuster beschreiben, erklären und angemessen anwenden (R3)
+==== LZ 03-09 [ehemaliges LZ 2-5]: Wichtige Entwurfsmuster beschreiben, erklären und angemessen anwenden (R3)
 
 Softwarearchitekt:innen können mehrere der folgenden Entwurfsmuster beschreiben, ihre Relevanz für die Architektur und konkrete Systeme erklären sowie Beispiele nennen. 
 
@@ -24,7 +24,7 @@ Softwarearchitekt:innen kennen wesentliche Quellen für Entwurfsmuster, wie z.B.
 // tag::EN[]
 [[LG-03-09]]
 
-==== LG 03-09 [previously LG 2-05]: Describe, Explain, and Appropriately Apply Important Design Patterns (R3)
+==== LG 03-09 [previously LG 2-5]: Describe, Explain, and Appropriately Apply Important Design Patterns (R3)
 
 Software can describe several of the following design patterns, explain their relevance for the architecture and specific systems and give examples. 
 

--- a/docs/03-design/LG-03-10.adoc
+++ b/docs/03-design/LG-03-10.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-03-10]]
-==== LZ 03-10 [ehemaliges LZ 2-04]: Querschnittsthemen identifizieren und Querschnittskonzepte entwerfen und umsetzen (R1)
+==== LZ 03-10 [ehemaliges LZ 2-4]: Querschnittsthemen identifizieren und Querschnittskonzepte entwerfen und umsetzen (R1)
 
 Softwarearchitekt:innen können:
 
@@ -17,7 +17,7 @@ Siehe auch <<LG-04-07>>.
 
 // tag::EN[]
 [[LG-03-10]]
-==== LG 03-10 [previously LG 2-04]: Identify, Design and Implement Cross-Cutting Concerns (R1)
+==== LG 03-10 [previously LG 2-4]: Identify, Design and Implement Cross-Cutting Concerns (R1)
 
 Software architects are able to:
 

--- a/docs/04-documentation/LG-04-01.adoc
+++ b/docs/04-documentation/LG-04-01.adoc
@@ -1,6 +1,6 @@
 // tag::DE[]
 [[LG-04-01]]
-==== LZ 04-01 [ehemaliges LZ 3-01]: Anforderungen an technische Dokumentation erläutern und berücksichtigen (R1)
+==== LZ 04-01 [ehemaliges LZ 3-1]: Anforderungen an technische Dokumentation erläutern und berücksichtigen (R1)
 
 Softwarearchitekt:innen kennen die wesentlichen Anforderungen an technische Dokumentation und können diese bei der Dokumentation von Systemen berücksichtigen bzw. erfüllen:
 
@@ -13,7 +13,7 @@ Sie wissen, dass Verständlichkeit technischer Dokumentation nur von deren Zielg
 
 // tag::EN[]
 [[LG-04-01]]
-==== LG 04-01 [previously LG 3-01]: Explain and Consider the Requirements of Technical Documentation (R1)
+==== LG 04-01 [previously LG 3-1]: Explain and Consider the Requirements of Technical Documentation (R1)
 Software architects know the essential requirements for technical documentation and can consider and fulfil them when documenting systems:
 
 * understandability, correctness, efficiency, appropriateness, maintainability

--- a/docs/04-documentation/LG-04-02.adoc
+++ b/docs/04-documentation/LG-04-02.adoc
@@ -1,6 +1,6 @@
 // tag::DE[]
 [[LG-04-02]]
-==== LZ 04-02 [ehemaliges LZ 3-02]: Softwarearchitekturen beschreiben und kommunizieren (R1-R3)
+==== LZ 04-02 [ehemaliges LZ 3-2]: Softwarearchitekturen beschreiben und kommunizieren (R1-R3)
 
 Softwarearchitekt:innen nutzen Dokumentation zur Unterstützung bei Entwurf, Implementierung und Weiterentwicklung (auch genannt _Wartung_ oder _Evolution_) von Systemen. (R2)
 
@@ -25,7 +25,7 @@ Sie können beispielsweise die folgenden Merkmale von Dokumentation je nach Situ
 
 // tag::EN[]
 [[LG-04-02]]
-==== LG 04-02 [previously LG 3-02]: Describe and Communicate Software Architectures (R1-R3)
+==== LG 04-02 [previously LG 3-2]: Describe and Communicate Software Architectures (R1-R3)
 
 Software architects use documentation to support the design, implementation and further development (also called _maintenance_ or _evolution_) of systems (R2)
 

--- a/docs/04-documentation/LG-04-03.adoc
+++ b/docs/04-documentation/LG-04-03.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-04-03]]
-==== LZ 04-03 [ehemaliges LZ 3-03]: Notations-/Modellierungsmittel für Beschreibung von Softwarearchitektur erläutern und anwenden (R2-R3)
+==== LZ 04-03 [ehemaliges LZ 3-3]: Notations-/Modellierungsmittel für Beschreibung von Softwarearchitektur erläutern und anwenden (R2-R3)
 
 Softwarearchitekt:innen kennen mindestens folgende UML-Diagramme zur Notation von Architektursichten:
 
@@ -22,7 +22,7 @@ Softwarearchitekt:innen kennen Alternativen zu UML, beispielsweise (R3)
 
 // tag::EN[]
 [[LG-04-03]]
-==== LG 04-03 [previously LG 3-03]: Explain and Apply Notations/Models to Describe Software Architecture (R2-R3)
+==== LG 04-03 [previously LG 3-3]: Explain and Apply Notations/Models to Describe Software Architecture (R2-R3)
 
 Software architects know at least the following UML diagrams to describe architectural views:
 

--- a/docs/04-documentation/LG-04-05.adoc
+++ b/docs/04-documentation/LG-04-05.adoc
@@ -1,6 +1,6 @@
 // tag::DE[]
 [[LG-04-05]]
-==== LZ 04-05 [ehemaliges LZ 3-04]: Architektursichten erläutern und anwenden (R1)
+==== LZ 04-05 [ehemaliges LZ 3-4]: Architektursichten erläutern und anwenden (R1)
 Softwarearchitekt:innen können folgende Architektursichten anwenden:
 
 * Kontextsicht (auch genannt Kontextabgrenzung)
@@ -16,7 +16,7 @@ Zusätzliche Sichten können nach Bedarf verwendet werden, um weitere Anliegen o
 
 // tag::EN[]
 [[LG-04-05]]
-==== LG 04-05 [previously LG 3-04]: Explain and Use Architectural Views (R1)
+==== LG 04-05 [previously LG 3-4]: Explain and Use Architectural Views (R1)
 Software architects are able to use the following architectural views:
 
 * context view

--- a/docs/04-documentation/LG-04-06.adoc
+++ b/docs/04-documentation/LG-04-06.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-04-06]]
-==== LZ 04-06 [ehemaliges LZ 3-07]: Schnittstellen dokumentieren (R1)
+==== LZ 04-06 [ehemaliges LZ 3-7]: Schnittstellen dokumentieren (R1)
 
 Softwarearchitekt:innen können sowohl interne als auch externe Schnittstellen dokumentieren.
 
@@ -11,7 +11,7 @@ Siehe auch <<LG-03-07>>.
 
 // tag::EN[]
 [[LG-04-06]]
-==== LG 04-06 [previously LG 3-07]: Document Interfaces (R1)
+==== LG 04-06 [previously LG 3-7]: Document Interfaces (R1)
 
 Software architects are able to document and specify both internal and external interfaces.
 

--- a/docs/04-documentation/LG-04-08.adoc
+++ b/docs/04-documentation/LG-04-08.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-04-08]]
-==== LZ 04-08 [ehemaliges LZ 3-08]: Architekturentscheidungen erläutern und dokumentieren (R1-R2)
+==== LZ 04-08 [ehemaliges LZ 3-8]: Architekturentscheidungen erläutern und dokumentieren (R1-R2)
 
 Softwarearchitekt:innen können:
 
@@ -13,7 +13,7 @@ Softwarearchitekt:innen kennen Architecture-Decision-Records (ADR, siehe <<nygar
 
 // tag::EN[]
 [[LG-04-08]]
-==== LG 04-08 [previously LG 3-08]: Explain and Document Architectural Decisions (R1-R2)
+==== LG 04-08 [previously LG 3-8]: Explain and Document Architectural Decisions (R1-R2)
 
 Software architects are able to:
 

--- a/docs/04-documentation/LG-04-09.adoc
+++ b/docs/04-documentation/LG-04-09.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-04-09]]
-==== LZ 04-09 [ehemaliges LZ 3-09]: Weitere Hilfsmittel und Werkzeuge zur Dokumentation kennen (R3)
+==== LZ 04-09 [ehemaliges LZ 3-9]: Weitere Hilfsmittel und Werkzeuge zur Dokumentation kennen (R3)
 
 Softwarearchitekt:innen kennen:
 
@@ -16,7 +16,7 @@ Softwarearchitekt:innen kennen:
 
 // tag::EN[]
 [[LG-04-09]]
-==== LG 04-09 [previously LG 3-09]: Know Additional Resources and Tools for Documentation (R3)
+==== LG 04-09 [previously LG 3-9]: Know Additional Resources and Tools for Documentation (R3)
 
 Software architects know:
 

--- a/docs/06-examples/LG-06-01.adoc
+++ b/docs/06-examples/LG-06-01.adoc
@@ -1,13 +1,13 @@
 // tag::DE[]
 [[LG-06-01]]
-==== LZ 06-01 [ehemaliges LZ 05-01]: Bezug von Anforderungen und Randbedingungen zur Lösung erfassen (R3)
+==== LZ 06-01 [ehemaliges LZ 5-1]: Bezug von Anforderungen und Randbedingungen zur Lösung erfassen (R3)
 Softwarearchitekt:innen haben an mindestens einem Beispiel den Bezug von Anforderungen und Randbedingungen zu Lösungsentscheidungen erkannt und nachvollzogen.
 
 // end::DE[]
 
 // tag::EN[]
 [[LG-06-01]]
-==== LG 06-01 [previous LG 05-01]: Know the Relation between Requirements, Constraints, and Solutions (R3)
+==== LG 06-01 [previous LG 5-1]: Know the Relation between Requirements, Constraints, and Solutions (R3)
 Software architects are expected to recognize and comprehend the correlation between requirements and constraints, and the chosen solutions using at least one example.
 
 // end::EN[]

--- a/docs/06-examples/LG-06-02.adoc
+++ b/docs/06-examples/LG-06-02.adoc
@@ -1,6 +1,6 @@
 // tag::DE[]
 [[LG-06-02]]
-==== LZ 06-02  [ehemaliges LZ 05-02]: Technische Umsetzung einer Lösung nachvollziehen (R3)
+==== LZ 06-02  [ehemaliges LZ 5-2]: Technische Umsetzung einer Lösung nachvollziehen (R3)
 
 Softwarearchitekt:innen können anhand mindestens eines Beispiels die technische Umsetzung (Implementierung, technische Konzepte, eingesetzte Produkte, Lösungsstrategien) einer Lösung nachvollziehen.
 
@@ -8,7 +8,7 @@ Softwarearchitekt:innen können anhand mindestens eines Beispiels die technische
 
 // tag::EN[]
 [[LG-06-02]]
-==== LG 06-02  [previous LG 05-02]: Understand the technical implementation of a solution (R3)
+==== LG 06-02  [previous LG 5-2]: Understand the technical implementation of a solution (R3)
 
 Software architects understand the technical realization (implementation, technical concepts, products used, architectural decisions, solution strategies) of at least one solution.
 


### PR DESCRIPTION
- numbers in old LGs had no leading zeros
- in some places this was correct (previously LG x-y), in some places we had x-0y, in some places even 0x-0y
- call me a bean counter