### PR TITLE
LG-02-02, fixed reference Gharbi+24

### DIFF
--- a/docs/02-requirements/LG-02-02.adoc
+++ b/docs/02-requirements/LG-02-02.adoc
@@ -88,4 +88,4 @@ Software architects are able to describe how those factors can influence archite
 // end::EN[]
 
 ===== {references}
-<<IREBFoundation>>, <<bass>>, <<ghandietal>>, <<starke>>, <<richardsfundamentals>>, <<pohl>>
+<<IREBFoundation>>, <<bass>>, <<gharbietal>>, <<starke>>, <<richardsfundamentals>>, <<pohl>>


### PR DESCRIPTION
next hotfix: In LG-02-02 we (wrongly) referenced "Head-First Architecture" instead of [Gharbi+24].

This PR fixes that.