### PR TITLE
Fix LG 03-08 term links

### DIFF
--- a/docs/03-design/LG-03-08.adoc
+++ b/docs/03-design/LG-03-08.adoc
@@ -44,9 +44,9 @@ Sie wissen:
 
 Software architects can explain and provide examples for the following architectural patterns (R1):
 
-* {glossary_url}layers[Layers]
+* {glossary_url}layer[Layers]
 * {glossary_url}pipes-and-filters[Pipes and Filters]
-* {glossary_url}microservices[Microservices]
+* {glossary_url}microservice[Microservices]
 
 Software architects can explain several of the following architectural patterns,
 explain their relevance for concrete systems, and provide examples. (R3)


### PR DESCRIPTION
Glossary links in LG 03-08 are not working: https://public.isaqb.org/curriculum-foundation/curriculum-foundation-en.html
