### PR TITLE
Elide questionable view examples.

### DIFF
--- a/docs/04-documentation/LG-04-05.adoc
+++ b/docs/04-documentation/LG-04-05.adoc
@@ -11,7 +11,7 @@ Softwarearchitekt:innen können folgende Architektursichten anwenden:
 * Laufzeitsicht (dynamische Sicht, Zusammenwirken der Softwarebausteine zur Laufzeit, Zustandsmodelle)
 * Verteilungs-/Deploymentsicht (Hardware und technische Infrastruktur sowie Abbildung von Softwarebausteinen auf diese Infrastruktur)
 
-Zusätzliche Sichten können nach Bedarf verwendet werden, um weitere Anliegen oder Anforderungen von Stakeholdern zu berücksichtigen, z. B. Funktionale Sicherheit, Informations-, Betriebs- oder User-Interface Sicht (R3).
+Zusätzliche Sichten können nach Bedarf verwendet werden, um weitere Anliegen oder Anforderungen von Stakeholdern zu berücksichtigen.  (R3)
 // end::DE[]
 
 // tag::EN[]
@@ -27,7 +27,7 @@ Software architects are able to use the following architectural views:
 * runtime view (dynamic view, interaction between software building blocks at runtime, state machines)
 * deployment view (hardware and technical infrastructure as well as the mapping of software building blocks onto the infrastructure)
 
-Additional views might be used as needed to address further stakeholder concerns and requirements, such as functional safety, information view,  operational view or user-interface view (R3).
+Additional views might be used as needed to address further stakeholder concerns and requirements. (R3)
 // end::EN[]
 
 ===== {references}


### PR DESCRIPTION
The sentence there is grammatically inconsistent, and it's unclear what a view on e.g. "functional safety" or "information" might be.