### PR TITLE
Bump documentation tools to R2

### DIFF
--- a/docs/04-documentation/LG-04-09.adoc
+++ b/docs/04-documentation/LG-04-09.adoc
@@ -1,7 +1,7 @@
 
 // tag::DE[]
 [[LG-04-09]]
-==== LZ 04-09 [ehemaliges LZ 3-9]: Weitere Hilfsmittel und Werkzeuge zur Dokumentation kennen (R3)
+==== LZ 04-09 [ehemaliges LZ 3-9]: Weitere Hilfsmittel und Werkzeuge zur Dokumentation kennen (R2)
 
 Softwarearchitekt:innen kennen:
 
@@ -16,7 +16,7 @@ Softwarearchitekt:innen kennen:
 
 // tag::EN[]
 [[LG-04-09]]
-==== LG 04-09 [previously LG 3-9]: Know Additional Resources and Tools for Documentation (R3)
+==== LG 04-09 [previously LG 3-9]: Know Additional Resources and Tools for Documentation (R2)
 
 Software architects know:
 


### PR DESCRIPTION
This makes arc42 and C4 R2

... but not ISO 42010, as it's intended to go in after #806.

As discussed at FLWG meeting in April.